### PR TITLE
Create a class to parse OCR data from raw exception record data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/CcdCollectionElement.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/CcdCollectionElement.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CcdCollectionElement<T> {
+
+    @JsonProperty
+    public final T value;
+
+    @JsonCreator
+    public CcdCollectionElement(@JsonProperty("value") T value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/ExceptionRecordFieldNames.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/ExceptionRecordFieldNames.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+
+public class ExceptionRecordFieldNames {
+    public static final String SCAN_OCR_DATA = "scanOCRData";
+    public static final String SCANNED_DOCUMENTS = "scannedDocuments";
+
+    private ExceptionRecordFieldNames() {
+        // utility class
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrData.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+
+import java.util.List;
+
+public class OcrData {
+
+    public final List<CcdCollectionElement<OcrDataField>> fields;
+
+    public OcrData(List<CcdCollectionElement<OcrDataField>> fields) {
+        this.fields = fields;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrDataField.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrDataField.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OcrDataField {
+
+    @JsonProperty
+    public final String key;
+
+    @JsonProperty
+    public final String value;
+
+    @JsonCreator
+    public OcrDataField(
+        @JsonProperty("key") String key,
+        @JsonProperty("value") String value
+    ) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/ResultOrErrors.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/ResultOrErrors.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Result of retrieving/parsing an object.
+ * <p>
+ * Contains either the retrieved object or a list of error messages.
+ * </p>
+ */
+public class ResultOrErrors<T> {
+
+    public final Optional<T> result;
+    public final List<String> errors;
+
+    private ResultOrErrors(Optional<T> result, List<String> errors) {
+        this.result = result;
+        this.errors = errors;
+    }
+
+    public static <T> ResultOrErrors<T> result(T result) {
+        return new ResultOrErrors<>(Optional.of(result), emptyList());
+    }
+
+    public static <T> ResultOrErrors<T> errors(List<String> errors) {
+        return new ResultOrErrors<>(Optional.empty(), errors);
+    }
+
+    public static <T> ResultOrErrors<T> errors(String... errors) {
+        return new ResultOrErrors<>(Optional.empty(), Arrays.asList(errors));
+    }
+
+    public boolean isSuccessful() {
+        return result.isPresent();
+    }
+
+    public T get() {
+        return result.get();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ExceptionRecordFieldNames.SCAN_OCR_DATA;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.errors;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.result;
+
+/**
+ * Converts raw exception record data representing OCR data fields
+ * (in the form of a list of maps of objects) into a strongly typed object.
+ */
+@Service
+public class OcrDataParser {
+
+    private final ObjectMapper mapper;
+
+    public OcrDataParser(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public ResultOrErrors<OcrData> parseOcrData(
+        Map<String, Object> exceptionRecordData
+    ) {
+        Object rawOcrData = exceptionRecordData.get(SCAN_OCR_DATA);
+
+        if (rawOcrData == null) {
+            return errors("Form OCR data is missing");
+        } else {
+            try {
+                return result(
+                    new OcrData(convertToOcrFieldList(rawOcrData))
+                );
+            } catch (IllegalArgumentException ex) {
+                return errors("Form OCR data has invalid format");
+            }
+        }
+    }
+
+    private List<CcdCollectionElement<OcrDataField>> convertToOcrFieldList(Object rawOcrData) {
+        JavaType ccdCollectionElementType =
+            mapper.getTypeFactory().constructParametricType(
+                CcdCollectionElement.class,
+                OcrDataField.class
+            );
+
+        JavaType type = mapper.getTypeFactory().constructParametricType(
+            List.class,
+            ccdCollectionElementType
+        );
+
+        return mapper.convertValue(rawOcrData, type);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
@@ -1,0 +1,103 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OcrDataParserTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final OcrDataParser ocrDataParser = new OcrDataParser(mapper);
+
+    @Test
+    public void should_return_ocr_data_when_valid() {
+        List<Object> rawOcrData = createRawOcrData(
+            ImmutableMap.of("field_1", "value 1", "field_2", "value 2")
+        );
+
+        Map<String, Object> exceptionRecordData = ImmutableMap.of(
+            "someProperty", "someValue",
+            "scanOCRData", rawOcrData
+        );
+
+        ResultOrErrors<OcrData> result = ocrDataParser.parseOcrData(exceptionRecordData);
+
+        assertTrue(result.isSuccessful());
+
+        OcrData parsedData = result.get();
+        assertThat(parsedData).isNotNull();
+
+        assertThat(parsedData.fields).isEqualToComparingFieldByFieldRecursively(
+            Arrays.asList(
+                new CcdCollectionElement<>(new OcrDataField("field_1", "value 1")),
+                new CcdCollectionElement<>(new OcrDataField("field_2", "value 2"))
+            )
+        );
+    }
+
+    @Test
+    public void should_return_error_when_format_is_invalid() {
+        List<Object> invalidOcrFieldList = Arrays.asList("field1", "field2");
+
+        Map<String, Object> exceptionRecordData = ImmutableMap.of(
+            "scanOCRData", invalidOcrFieldList
+        );
+
+        ResultOrErrors<OcrData> result = ocrDataParser.parseOcrData(exceptionRecordData);
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.errors).isEqualTo(Arrays.asList("Form OCR data has invalid format"));
+    }
+
+    @Test
+    public void should_return_error_when_null() {
+        Map<String, Object> exceptionRecordData = new HashMap<>();
+        exceptionRecordData.put("scanOCRData", null);
+
+        ResultOrErrors<OcrData> result = ocrDataParser.parseOcrData(exceptionRecordData);
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.errors).isEqualTo(Arrays.asList("Form OCR data is missing"));
+    }
+
+    @Test
+    public void should_return_error_when_absent() {
+        Map<String, Object> exceptionRecordData = ImmutableMap.of("notOcrData", "some value");
+
+        ResultOrErrors<OcrData> result = ocrDataParser.parseOcrData(exceptionRecordData);
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.errors).isEqualTo(Arrays.asList("Form OCR data is missing"));
+    }
+
+    private List<Object> createRawOcrData(Map<String, String> fields) {
+        return fields
+            .entrySet()
+            .stream()
+            .map(
+                entry -> {
+                    Map<String, Object> keyValue = ImmutableMap.of(
+                        "key", entry.getKey(),
+                        "value", entry.getValue()
+                    );
+
+                    return ImmutableMap.of("value", keyValue);
+                }
+            )
+            .collect(toList());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-570

### Change description ###

This one needs to be merged first: https://github.com/hmcts/bulk-scan-ccd-event-handler-sample-app/pull/7

Create a class to parse OCR data from raw exception record data. This class is needed for the construction of CCD case data, as most of the fields will come from OCR data.

While this is quite a big PR, a good portion of the code is models.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
