### PR TITLE
Prevent PMD warnings from failing the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ checkstyle {
 
 pmd {
   toolVersion = "6.14.0"
+  ignoreFailures = true
   sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
   reportsDir = file("$project.buildDir/reports/pmd")
   ruleSetFiles = files("config/pmd/ruleset.xml")


### PR DESCRIPTION
### Change description ###

Prevent PMD warnings from failing the build (just like in other bulk-scan projects)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
