### PR TITLE
Throw exception when OCR data is malformed

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CallbackProcessingException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CcdDataParseException;
 
 import java.util.Map;
@@ -20,8 +19,6 @@ import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.r
  */
 @Service
 public class OcrDataParser {
-
-    private static final Logger log = LoggerFactory.getLogger(OcrDataParser.class);
 
     private final CcdCollectionParser ccdCollectionParser;
 
@@ -44,8 +41,7 @@ public class OcrDataParser {
                     )
                 );
             } catch (CcdDataParseException e) {
-                log.warn("Failed to parse OCR data", e);
-                return errors("Form OCR data has invalid format");
+                throw new CallbackProcessingException("Failed to parse OCR data from exception record", e);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CallbackProcessingException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CcdDataParseException;
 
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,19 +70,18 @@ public class OcrDataParserTest {
     }
 
     @Test
-    public void should_return_error_when_format_is_invalid() {
+    public void should_throw_exception_when_format_is_invalid() {
         // given
         CcdDataParseException exceptionToThrow = new CcdDataParseException("Test exception", null);
         willThrow(exceptionToThrow).given(ccdCollectionParser).parseCcdCollection(any(), any());
 
         Map<String, Object> exceptionRecordData = ImmutableMap.of("scanOCRData", new Object());
 
-        // when
-        ResultOrErrors<OcrData> result = ocrDataParser.parseOcrData(exceptionRecordData);
-
-        // then
-        assertFalse(result.isSuccessful());
-        assertThat(result.errors).isEqualTo(Arrays.asList("Form OCR data has invalid format"));
+        assertThatThrownBy(() ->
+            ocrDataParser.parseOcrData(exceptionRecordData)
+        )
+            .isInstanceOf(CallbackProcessingException.class)
+            .hasMessage("Failed to parse OCR data from exception record");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-570

### Change description ###

Make OCR data parser throw exception when OCR data is malformed. This will result in a 400 response, leading to CCD displaying a general error message to the caseworker.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
