### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.7.RELEASE'
-  id 'org.springframework.boot' version '2.1.4.RELEASE' // remove tomcat version force below when updating spring boot version
+  id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+  id 'org.springframework.boot' version '2.1.6.RELEASE'
   id 'org.owasp.dependencycheck' version '5.0.0'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
@@ -148,26 +148,9 @@ ext["rest-assured.version"] = '4.0.0'
 
 dependencyManagement {
   dependencies {
-    // CVE-2019-0232 - command line injections on windows - fixed on spring boot master but not released
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.19') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-el'
-      entry 'tomcat-embed-websocket'
-    }
-
     // align with jupiter version
     dependencySet(group: 'org.mockito', version: '3.0.0') {
       entry 'mockito-core'
-    }
-  }
-}
-
-configurations.all {
-  resolutionStrategy {
-    eachDependency { DependencyResolveDetails details ->
-      if (details.requested.group in ['com.fasterxml.jackson.core', 'com.fasterxml.jackson.module', 'com.fasterxml.jackson.datatype']) {
-        details.useVersion '2.9.9'
-      }
     }
   }
 }
@@ -177,13 +160,13 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-  compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.3'
+  compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.0.RELEASE'
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.2.RELEASE'
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
   id 'org.springframework.boot' version '2.1.6.RELEASE'
-  id 'org.owasp.dependencycheck' version '5.0.0'
-  id 'com.github.ben-manes.versions' version '0.20.0'
-  id 'org.sonarqube' version '2.6.2'
+  id 'org.owasp.dependencycheck' version '5.1.1'
+  id 'com.github.ben-manes.versions' version '0.21.0'
+  id 'org.sonarqube' version '2.7.1'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,10 @@ ext["rest-assured.version"] = '4.0.0'
 
 dependencyManagement {
   dependencies {
+    // CVE-2019-12814
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.1') {
+      entry 'jackson-databind'
+    }
     // align with jupiter version
     dependencySet(group: 'org.mockito', version: '3.0.0') {
       entry 'mockito-core'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
### Change description ###

Dependency vulnerability fixes:

- tomcat definition enforced by manager, should be fixed with latest spring boot plugin
- `jackson-databind` brought in by spring boot. hotfixing

Update some plugins:

- gradle 5.4.1 -> 5.5.1
- owasp 5.0.0 -> 5.1.1
- ben manes 0.20.0 -> 0.21.0
- sonarqube 2.6.2 -> 2.7.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
