### PR TITLE
Refactor ocr data field model

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
@@ -77,7 +77,7 @@ class OcrValidationTest {
     }
 
     @Test
-    void should_return_warnings_when_ocr_form_data_has_missing_fields() throws Throwable {
+    void should_return_warnings_when_ocr_form_data_has_missing_optional_fields() throws Throwable {
         String content = readResource("ocr-data/invalid/missing-optional-fields.json");
 
         mvc.perform(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@ComponentScan(basePackages = "...", lazyInit = true)
+@ContextConfiguration
+@SpringBootTest
+@TestPropertySource("classpath:application.conf")
+class OcrValidationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void should_return_200_when_ocr_form_validation_request_data_is_valid() throws Throwable {
+        String content = readResource("ocr-data/valid/valid-ocr-data.json");
+
+        mvc.perform(
+            post("/validate-ocr-data")
+                .header("ServiceAuthorization", "auth-header-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("SUCCESS"))
+            .andExpect(jsonPath("$.warnings", hasSize(0)))
+            .andExpect(jsonPath("$.errors", hasSize(0)));
+    }
+
+    @Test
+    void should_return_errors_when_ocr_data_contains_duplicate_fields() throws Throwable {
+        String content = readResource("ocr-data/invalid/duplicate-fields.json");
+
+        mvc.perform(
+            post("/validate-ocr-data")
+                .header("ServiceAuthorization", "auth-header-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("ERRORS"))
+            .andExpect(jsonPath("$.warnings", hasSize(0)))
+            .andExpect(jsonPath("$.errors", hasSize(1)))
+            .andExpect(jsonPath("$.errors[0]").value("Invalid OCR data. Duplicate keys exist: last_name"));
+    }
+
+    @Test
+    void should_return_errors_when_ocr_form_data_has_missing_mandatory_fields() throws Throwable {
+        String content = readResource("ocr-data/invalid/missing-mandatory-fields.json");
+
+        mvc.perform(
+            post("/validate-ocr-data")
+                .header("ServiceAuthorization", "auth-header-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("ERRORS"))
+            .andExpect(jsonPath("$.errors", hasSize(1)))
+            .andExpect(jsonPath("$.warnings", hasSize(0)))
+            .andExpect(jsonPath("$.errors[0]").value("last_name is missing"));
+    }
+
+    @Test
+    void should_return_warnings_when_ocr_form_data_has_missing_fields() throws Throwable {
+        String content = readResource("ocr-data/invalid/missing-optional-fields.json");
+
+        mvc.perform(
+            post("/validate-ocr-data")
+                .header("ServiceAuthorization", "auth-header-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("WARNINGS"))
+            .andExpect(jsonPath("$.errors", hasSize(0)))
+            .andExpect(jsonPath("$.warnings", hasSize(1)))
+            .andExpect(jsonPath("$.warnings[0]").value("date_of_birth is missing"));
+    }
+
+    @Test
+    void should_return_401_when_service_auth_header_is_missing() throws Throwable {
+        String content = readResource("ocr-data/invalid/missing-optional-fields.json");
+
+        mvc.perform(
+            post("/validate-ocr-data")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+            .andExpect(status().isUnauthorized());
+    }
+
+    private String readResource(final String fileName) throws IOException {
+        return Resources.toString(Resources.getResource(fileName), Charsets.UTF_8);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
@@ -57,7 +57,7 @@ class OcrValidationTest {
             .andExpect(jsonPath("$.status").value("ERRORS"))
             .andExpect(jsonPath("$.warnings", hasSize(0)))
             .andExpect(jsonPath("$.errors", hasSize(1)))
-            .andExpect(jsonPath("$.errors[0]").value("Invalid OCR data. Duplicate keys exist: last_name"));
+            .andExpect(jsonPath("$.errors[0]").value("Invalid OCR data. Duplicate fields exist: last_name"));
     }
 
     @Test

--- a/src/integrationTest/resources/application.conf
+++ b/src/integrationTest/resources/application.conf
@@ -1,0 +1,4 @@
+idam.s2s-auth.url=false
+core_case_data.api.url=http://localhost:4452
+
+allowed-services=some_service_name

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrDataField.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrDataField.java
@@ -6,17 +6,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class OcrDataField {
 
     @JsonProperty
-    public final String key;
+    public final String name;
 
     @JsonProperty
     public final String value;
 
     @JsonCreator
     public OcrDataField(
-        @JsonProperty("key") String key,
+        @JsonProperty("name") String name,
         @JsonProperty("value") String value
     ) {
-        this.key = key;
+        this.name = name;
         this.value = value;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataValidator.java
@@ -38,9 +38,9 @@ public class OcrDataValidator {
     private static final Logger log = LoggerFactory.getLogger(OcrDataValidator.class);
 
     public OcrValidationResult validate(FormType formType, List<OcrDataField> ocrData) {
-        List<String> duplicateOcrKeys = OcrFormValidationHelper.findDuplicateOcrKeys(ocrData);
+        List<String> duplicateOcrFields = OcrFormValidationHelper.findDuplicateOcrFields(ocrData);
 
-        if (duplicateOcrKeys.isEmpty()) {
+        if (duplicateOcrFields.isEmpty()) {
             List<String> errors = validateMandatoryFields(formType, ocrData);
             List<String> warnings = validateOptionalFields(formType, ocrData);
 
@@ -48,10 +48,10 @@ public class OcrDataValidator {
                 warnings, errors, getValidationStatus(!errors.isEmpty(), !warnings.isEmpty())
             );
         } else {
-            String duplicateKeys = String.join(",", duplicateOcrKeys);
-            log.info("Found duplicate keys in OCR data. {}", duplicateKeys);
+            String duplicateFields = String.join(",", duplicateOcrFields);
+            log.info("Found duplicate fields in OCR data. {}", duplicateFields);
 
-            String errorMessage = String.format("Invalid OCR data. Duplicate keys exist: %s", duplicateKeys);
+            String errorMessage = String.format("Invalid OCR data. Duplicate fields exist: %s", duplicateFields);
             return new OcrValidationResult(emptyList(), singletonList(errorMessage), ERRORS);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetriever.java
@@ -65,7 +65,7 @@ public class OcrFieldRetriever {
         return ocrData
             .fields
             .stream()
-            .filter(e -> fieldName.equals(e.value.key))
+            .filter(e -> fieldName.equals(e.value.name))
             .collect(toList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/util/OcrFormValidationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/util/OcrFormValidationHelper.java
@@ -22,7 +22,7 @@ public final class OcrFormValidationHelper {
     public static List<String> getOcrFieldNames(List<OcrDataField> ocrData) {
         return ocrData
             .stream()
-            .map(field -> field.key)
+            .map(field -> field.name)
             .collect(toList());
     }
 
@@ -43,7 +43,7 @@ public final class OcrFormValidationHelper {
     public static String findOcrFormFieldValue(String fieldName, List<OcrDataField> ocrData) {
         return ocrData
             .stream()
-            .filter(e -> fieldName.equals(e.key))
+            .filter(e -> fieldName.equals(e.name))
             .findFirst()
             .map(v -> v.value)
             .orElse(null);
@@ -57,10 +57,10 @@ public final class OcrFormValidationHelper {
         return Pattern.compile("\\d{10}").matcher(phone).matches();
     }
 
-    public static List<String> findDuplicateOcrKeys(List<OcrDataField> ocrKeys) {
-        return ocrKeys
+    public static List<String> findDuplicateOcrFields(List<OcrDataField> ocrFields) {
+        return ocrFields
             .stream()
-            .collect(groupingBy(it -> it.key, counting()))
+            .collect(groupingBy(it -> it.name, counting()))
             .entrySet()
             .stream()
             .filter(entry -> entry.getValue() > 1)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseCreationCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseCreationCallbackHandlerTest.java
@@ -138,7 +138,7 @@ public class CaseCreationCallbackHandlerTest {
             .jurisdiction("jurisdiction1")
             .state("state1")
             .caseTypeId("caseTypeId1")
-            .data(ImmutableMap.of("key1", "value1"))
+            .data(ImmutableMap.of("name1", "value1"))
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseTransformerTest.java
@@ -127,7 +127,7 @@ public class CaseTransformerTest {
             "jurisdiction1",
             "state1",
             "caseTypeId1",
-            ImmutableMap.of("key1", "value1")
+            ImmutableMap.of("name1", "value1")
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/data/SampleCaseConversionData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/data/SampleCaseConversionData.java
@@ -153,11 +153,11 @@ public final class SampleCaseConversionData {
             PARSED_SCANNED_DOCUMENTS
         );
 
-    private static Map<String, Object> rawOcrField(String key, String value) {
+    private static Map<String, Object> rawOcrField(String name, String value) {
         return ImmutableMap.of(
             "value",
             ImmutableMap.of(
-                "key", key,
+                "name", name,
                 "value", value
             )
         );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -49,12 +49,12 @@ class OcrDataValidatorTest {
     }
 
     @Test
-    void should_return_errors_when_duplicate_keys_exist() {
+    void should_return_errors_when_ocr_data_contains_duplicate_field_names() {
         // given
         List<OcrDataField> ocrDataFields = asList(
             new OcrDataField(FIRST_NAME, "name"),
-            new OcrDataField(LAST_NAME, "xyz"), //duplicate key
-            new OcrDataField(LAST_NAME, "abc"), //duplicate key
+            new OcrDataField(LAST_NAME, "xyz"), //duplicate field name
+            new OcrDataField(LAST_NAME, "abc"), //duplicate field name
             new OcrDataField(DATE_OF_BIRTH, "01-01-1990")
         );
 
@@ -66,7 +66,7 @@ class OcrDataValidatorTest {
         assertThat(result)
             .extracting("errors", "warnings", "status")
             .containsExactly(
-                singletonList("Invalid OCR data. Duplicate keys exist: last_name"),
+                singletonList("Invalid OCR data. Duplicate fields exist: last_name"),
                 emptyList(),
                 ValidationStatus.ERRORS
             );

--- a/src/test/resources/ocr-data/invalid/duplicate-fields.json
+++ b/src/test/resources/ocr-data/invalid/duplicate-fields.json
@@ -1,20 +1,20 @@
 {
   "ocr_data_fields": [
     {
-      "key": "first_name",
+      "name": "first_name",
       "value": "John"
     },
     {
-      "key": "last_name",
+      "name": "last_name",
       "value": "Test"
     },
     {
-      "key": "last_name",
+      "name": "last_name",
       "value": "duplicate"
     },
     {
-      "key": "date_of_birth",
-      "value": "01-01-1990"
+      "name": "date_of_birth",
+      "value": "1990-01-01"
     }
   ],
   "form_type": "PERSONAL"

--- a/src/test/resources/ocr-data/invalid/duplicate-fields.json
+++ b/src/test/resources/ocr-data/invalid/duplicate-fields.json
@@ -1,0 +1,21 @@
+{
+  "ocr_data_fields": [
+    {
+      "key": "first_name",
+      "value": "John"
+    },
+    {
+      "key": "last_name",
+      "value": "Test"
+    },
+    {
+      "key": "last_name",
+      "value": "duplicate"
+    },
+    {
+      "key": "date_of_birth",
+      "value": "01-01-1990"
+    }
+  ],
+  "form_type": "PERSONAL"
+}

--- a/src/test/resources/ocr-data/invalid/invalid-form-type.json
+++ b/src/test/resources/ocr-data/invalid/invalid-form-type.json
@@ -1,11 +1,11 @@
 {
   "ocr_data_fields": [
     {
-      "key": "firstName",
+      "name": "firstName",
       "value": "John"
     },
     {
-      "key": "lastName",
+      "name": "lastName",
       "value": "Smith"
     }
   ],

--- a/src/test/resources/ocr-data/invalid/missing-form-type.json
+++ b/src/test/resources/ocr-data/invalid/missing-form-type.json
@@ -1,11 +1,11 @@
 {
   "ocr_data_fields": [
     {
-      "key": "firstName",
+      "name": "firstName",
       "value": "John"
     },
     {
-      "key": "lastName",
+      "name": "lastName",
       "value": "Smith"
     }
   ]

--- a/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
@@ -1,0 +1,13 @@
+{
+  "ocr_data_fields": [
+    {
+      "key": "first_name",
+      "value": "John"
+    },
+    {
+      "key": "date_of_birth",
+      "value": "01-01-1990"
+    }
+  ],
+  "form_type": "PERSONAL"
+}

--- a/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
@@ -1,12 +1,12 @@
 {
   "ocr_data_fields": [
     {
-      "key": "first_name",
+      "name": "first_name",
       "value": "John"
     },
     {
-      "key": "date_of_birth",
-      "value": "01-01-1990"
+      "name": "date_of_birth",
+      "value": "1990-01-31"
     }
   ],
   "form_type": "PERSONAL"

--- a/src/test/resources/ocr-data/invalid/missing-optional-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-optional-fields.json
@@ -1,0 +1,13 @@
+{
+  "ocr_data_fields": [
+    {
+      "key": "first_name",
+      "value": "John"
+    },
+    {
+      "key": "last_name",
+      "value": "Smith"
+    }
+  ],
+  "form_type": "PERSONAL"
+}

--- a/src/test/resources/ocr-data/invalid/missing-optional-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-optional-fields.json
@@ -1,11 +1,11 @@
 {
   "ocr_data_fields": [
     {
-      "key": "first_name",
+      "name": "first_name",
       "value": "John"
     },
     {
-      "key": "last_name",
+      "name": "last_name",
       "value": "Smith"
     }
   ],

--- a/src/test/resources/ocr-data/valid/valid-ocr-data.json
+++ b/src/test/resources/ocr-data/valid/valid-ocr-data.json
@@ -1,15 +1,15 @@
 {
   "ocr_data_fields": [
     {
-      "key": "first_name",
+      "name": "first_name",
       "value": "John"
     },
     {
-      "key": "last_name",
+      "name": "last_name",
       "value": "Smith"
     },
     {
-      "key": "date_of_birth",
+      "name": "date_of_birth",
       "value": "10-10-2000"
     }
   ],


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-683


### Change description ###
Refactor OcrDateField model to rename `key` as `field` which holds the Ocr form field names.
According to the Tech Spec, Ocr validation endpoint request body should have the ocr field name property as `name`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
