### PR TITLE
Bug - Contact form optional fields list should be different from mandatory fields 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataValidator.java
@@ -108,11 +108,10 @@ public class OcrDataValidator {
     private List<String> getOptionalFieldsForForm(FormType formType) {
         if (formType.equals(CONTACT)) {
             return asList(
-                OcrFieldNames.ADDRESS_LINE_1,
-                OcrFieldNames.EMAIL,
-                OcrFieldNames.POST_CODE,
-                OcrFieldNames.COUNTRY,
-                OcrFieldNames.CONTACT_NUMBER
+                OcrFieldNames.ADDRESS_LINE_2,
+                OcrFieldNames.ADDRESS_LINE_3,
+                OcrFieldNames.POST_TOWN,
+                OcrFieldNames.COUNTY
             );
         } else if (formType.equals(PERSONAL)) {
             return singletonList(OcrFieldNames.DATE_OF_BIRTH);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -15,13 +15,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.PERSONAL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_3;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.CONTACT_NUMBER;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTY;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.DATE_OF_BIRTH;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.EMAIL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.FIRST_NAME;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.LAST_NAME;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_TOWN;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.ERRORS;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.SUCCESS;
 
@@ -161,7 +165,11 @@ class OcrDataValidatorTest {
         // given
         List<OcrDataField> ocrDataFields = asList(
             new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
+            new OcrDataField(ADDRESS_LINE_3, "London"),
+            new OcrDataField(POST_TOWN, "LONDON"),
             new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
             new OcrDataField(COUNTRY, "UK"),
             new OcrDataField(EMAIL, "xyz"), //invalid email address
             new OcrDataField(CONTACT_NUMBER, "0123456789")
@@ -186,7 +194,11 @@ class OcrDataValidatorTest {
         // given
         List<OcrDataField> ocrDataFields = asList(
             new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
+            new OcrDataField(ADDRESS_LINE_3, "London"),
+            new OcrDataField(POST_TOWN, "LONDON"),
             new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
             new OcrDataField(COUNTRY, "UK"),
             new OcrDataField(EMAIL, "test@test.com"),
             new OcrDataField(CONTACT_NUMBER, "invalid") //invalid phone number
@@ -211,7 +223,11 @@ class OcrDataValidatorTest {
         // given
         List<OcrDataField> ocrDataFields = asList(
             new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
+            new OcrDataField(ADDRESS_LINE_3, "London"),
+            new OcrDataField(POST_TOWN, "LONDON"),
             new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
             new OcrDataField(COUNTRY, "UK"),
             new OcrDataField(EMAIL, "test@test.com"), //valid email format
             new OcrDataField(CONTACT_NUMBER, "0123456789") //valid phone number format

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -219,6 +219,36 @@ class OcrDataValidatorTest {
     }
 
     @Test
+    void should_return_warnings_when_contact_form_optional_fields_are_missing() {
+        // given
+        List<OcrDataField> ocrDataFields = asList(
+            new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
+            new OcrDataField(COUNTRY, "UK"),
+            new OcrDataField(EMAIL, "test@test.com"),
+            new OcrDataField(CONTACT_NUMBER, "0123456789")
+        );
+
+        // when
+        OcrValidationResult result = validator.validate(CONTACT, ocrDataFields);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result)
+            .extracting("errors", "warnings", "status")
+            .containsExactly(
+                emptyList(),
+                asList(
+                    "address_line_2 is missing",
+                    "address_line_3 is missing",
+                    "post_town is missing"
+                ),
+                ValidationStatus.WARNINGS
+            );
+    }
+
+    @Test
     void should_return_success_when_contact_form_fields_format_is_valid() {
         // given
         List<OcrDataField> ocrDataFields = asList(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-683

### Change description ###
The OCR validation for optional fields is always checking the mandatory fields as they are defined incorrectly. 
Updated the contact form optional field names list to be different from the mandatory field names.
Added a test for Contact form missing optional fields.
(Contact form is one of the OCR form types in sample app - PERSONAL, CONTACT)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
