### PR TITLE
Move ocr validation to separate package

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResponse;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.OcrValidationResponse;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ResponseExceptionHandler.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.exceptions.FormNotFoundException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.ForbiddenException;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.FormNotFoundException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.UnauthenticatedException;
 
 import static org.springframework.http.HttpStatus.FORBIDDEN;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/common/OcrFieldNames.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/common/OcrFieldNames.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.shared;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.common;
 
 public final class OcrFieldNames {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/FormType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/FormType.java
@@ -1,6 +1,0 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
-
-public enum FormType {
-    CONTACT,
-    PERSONAL
-}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/OcrData.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
 
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
+
 import java.util.List;
 
 public class OcrData {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/out/ValidationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/model/out/ValidationStatus.java
@@ -1,7 +1,0 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out;
-
-public enum ValidationStatus {
-    SUCCESS,
-    WARNINGS,
-    ERRORS
-}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/controllers/OcrValidationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/controllers/OcrValidationController.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.controllers;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.controllers;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -12,13 +12,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.in.OcrDataValidationRequest;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResponse;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataValidationRequest;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.OcrValidationResponse;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrDataValidator;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrValidationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.exceptions.FormNotFoundException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.AuthService;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.OcrDataValidator;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.FormNotFoundException;
 
 import javax.validation.Valid;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/FormType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/FormType.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model;
+
+public enum FormType {
+    CONTACT,
+    PERSONAL
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/in/OcrDataField.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/in/OcrDataField.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/in/OcrDataValidationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/in/OcrDataValidationRequest.java
@@ -1,8 +1,7 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model.in;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/out/OcrValidationResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/out/OcrValidationResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/out/ValidationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/out/ValidationStatus.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out;
+
+public enum ValidationStatus {
+    SUCCESS,
+    WARNINGS,
+    ERRORS
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -1,13 +1,11 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResult;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.util.OcrFormValidationHelper;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,26 +13,26 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.CONTACT;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.PERSONAL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_TOWN;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.ERRORS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.SUCCESS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.WARNINGS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.util.OcrFormValidationHelper.getOcrFieldNames;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.util.OcrFormValidationHelper.isValidEmailAddress;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.util.OcrFormValidationHelper.isValidPhoneNumber;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.WARNINGS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.getOcrFieldNames;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.isValidEmailAddress;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.isValidPhoneNumber;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
 
 @Service
 public class OcrDataValidator {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -13,6 +13,18 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_TOWN;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
@@ -21,18 +33,6 @@ import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.ou
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.getOcrFieldNames;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.isValidEmailAddress;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrFormValidationHelper.isValidPhoneNumber;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
 
 @Service
 public class OcrDataValidator {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrFormValidationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrFormValidationHelper.java
@@ -1,7 +1,7 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.util;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services;
 
 import org.apache.commons.validator.routines.EmailValidator;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrValidationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrValidationResult.java
@@ -1,4 +1,6 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services;
+
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/exceptions/FormNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/exceptions/FormNotFoundException.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.exceptions;
 
 public class FormNotFoundException extends RuntimeException {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseDataCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseDataCreator.java
@@ -15,21 +15,21 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LEGACY_ID;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_TOWN;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.errors;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.result;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LEGACY_ID;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
 
 @Service
 public class CaseDataCreator {
@@ -126,7 +126,8 @@ public class CaseDataCreator {
                     postCode.get(),
                     postTown.get(),
                     county.get(),
-                    country.get())
+                    country.get()
+                )
             );
         } else {
             return errors(fieldErrors);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseDataCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/CaseDataCreator.java
@@ -15,21 +15,21 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.LEGACY_ID;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_TOWN;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.errors;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors.result;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LEGACY_ID;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
 
 @Service
 public class CaseDataCreator {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParser.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CallbackProcessingException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CcdDataParseException;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetriever.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/shared/OcrFieldNames.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/shared/OcrFieldNames.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscanccdeventhandler.model;
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.shared;
 
 public final class OcrFieldNames {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/controllers/OcrValidationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/controllers/OcrValidationControllerTest.java
@@ -10,12 +10,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.controllers.OcrValidationController;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrDataValidator;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrValidationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.exceptions.FormNotFoundException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.AuthService;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.OcrDataValidator;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.ForbiddenException;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.FormNotFoundException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.UnauthenticatedException;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.SUCCESS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
 
 @WebMvcTest(OcrValidationController.class)
 class OcrValidationControllerTest {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrDataParserTest.java
@@ -8,8 +8,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CallbackProcessingException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.exception.CcdDataParseException;
 
@@ -78,7 +78,7 @@ public class OcrDataParserTest {
         Map<String, Object> exceptionRecordData = ImmutableMap.of("scanOCRData", new Object());
 
         assertThatThrownBy(() ->
-            ocrDataParser.parseOcrData(exceptionRecordData)
+                               ocrDataParser.parseOcrData(exceptionRecordData)
         )
             .isInstanceOf(CallbackProcessingException.class)
             .hasMessage("Failed to parse OCR data from exception record");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetrieverTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 
 import java.time.LocalDate;
 import java.util.Arrays;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/OcrFieldRetrieverTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ResultOrErrors;
 
 import java.time.LocalDate;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/data/SampleCaseConversionData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/services/data/SampleCaseConversionData.java
@@ -6,8 +6,8 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.BulkScanCase;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrData;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.validators;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrDataField;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.OcrValidationResult;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.services.OcrDataValidator;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrValidationResult;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrDataValidator;
 
 import java.util.List;
 
@@ -12,22 +12,22 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.CONTACT;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.FormType.PERSONAL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.OcrFieldNames.POST_TOWN;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.ERRORS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.model.out.ValidationStatus.SUCCESS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
 
 class OcrDataValidatorTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -2,9 +2,9 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.validators;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrValidationResult;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrDataValidator;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.services.OcrValidationResult;
 
 import java.util.List;
 
@@ -14,6 +14,8 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
@@ -26,8 +28,6 @@ import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.F
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
 
 class OcrDataValidatorTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -12,22 +12,22 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.CONTACT_NUMBER;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTRY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.COUNTY;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.DATE_OF_BIRTH;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.EMAIL;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.FIRST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LAST_NAME;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_CODE;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_TOWN;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_1;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_2;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.ADDRESS_LINE_3;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.CONTACT_NUMBER;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTRY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.COUNTY;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.DATE_OF_BIRTH;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.EMAIL;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.FIRST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.LAST_NAME;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_CODE;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.shared.OcrFieldNames.POST_TOWN;
 
 class OcrDataValidatorTest {
 


### PR DESCRIPTION
Refactoring package structure in preparation for adding 'exception record -> case' transformation functionality.

Constants with OCR field names were used in both ocr validation services as well as in ccd callback services so I've moved it to `shared` package.