### PR TITLE
Bumped Jackson databind version to resolve CVE-2019-14379

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ ext["rest-assured.version"] = '4.0.0'
 dependencyManagement {
   dependencies {
     // CVE-2019-12814
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.1') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
       entry 'jackson-databind'
     }
     // align with jupiter version


### PR DESCRIPTION
- Resolves CVE-2019-14379