### PR TITLE
Rename scanned doc model

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/ExceptionRecord.java
@@ -15,7 +15,7 @@ public class ExceptionRecord {
     public final JourneyClassification journeyClassification;
     public final LocalDateTime deliveryDate;
     public final LocalDateTime openingDate;
-    public final List<ScannedDocument> scannedDocuments;
+    public final List<InputScannedDoc> scannedDocuments;
     public final List<OcrDataField> ocrDataFields;
 
     public ExceptionRecord(
@@ -26,7 +26,7 @@ public class ExceptionRecord {
         @JsonProperty("journey_classification") JourneyClassification journeyClassification,
         @JsonProperty("delivery_date") LocalDateTime deliveryDate,
         @JsonProperty("opening_date") LocalDateTime openingDate,
-        @JsonProperty("scanned_documents") List<ScannedDocument> scannedDocuments,
+        @JsonProperty("scanned_documents") List<InputScannedDoc> scannedDocuments,
         @JsonProperty("ocr_data_fields") List<OcrDataField> ocrDataFields
     ) {
         this.id = id;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDoc.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDoc.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 
-public class ScannedDocument {
+public class InputScannedDoc {
 
     public final String type;
     public final String subtype;
@@ -14,7 +14,7 @@ public class ScannedDocument {
     public final LocalDateTime scannedDate;
     public final LocalDateTime deliveryDate;
 
-    public ScannedDocument(
+    public InputScannedDoc(
         @JsonProperty("type") String type,
         @JsonProperty("subtype") String subtype,
         @JsonProperty("url") String url,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
 
 @Component
 public class DocumentMapper {
@@ -11,7 +12,7 @@ public class DocumentMapper {
      * Converts document in Exception Record model to document in Case model.
      */
     public CcdCollectionElement<ScannedDocument> toCaseDoc(
-        uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ScannedDocument exceptionRecordDoc,
+        InputScannedDoc exceptionRecordDoc,
         String exceptionRecordReference
     ) {
         return new CcdCollectionElement<>(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/ModelTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/ModelTest.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/ModelTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/ModelTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
 
@@ -34,7 +34,7 @@ public class ModelTest {
                 LocalDateTime.now(),
                 LocalDateTime.now(),
                 singletonList(
-                    new ScannedDocument(
+                    new InputScannedDoc(
                         "type",
                         "subtype",
                         "http://localhost/123",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
@@ -10,8 +10,8 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
 
 import static java.time.LocalDateTime.now;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.model.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
 
 import static java.time.LocalDateTime.now;
@@ -61,8 +61,8 @@ public class ExceptionRecordToCaseTransformerTest {
             now(),
             now(),
             asList(
-                new ScannedDocument("type1", "subtype1", "url1", "dcn1", "filename1", now(), now()),
-                new ScannedDocument("type2", "subtype2", "url2", "dcn2", "filename2", now(), now())
+                new InputScannedDoc("type1", "subtype1", "url1", "dcn1", "filename1", now(), now()),
+                new InputScannedDoc("type2", "subtype2", "url2", "dcn2", "filename2", now(), now())
             ),
             asList(
                 new OcrDataField(OcrFieldNames.FIRST_NAME, "John"),


### PR DESCRIPTION
Both input (exception record) and output (case) scannable item models have the same now right now, which requires using fully qualified name in some places.
