### PR TITLE
Wrap scannable items for CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/Item.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/Item.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wrapper class for CCD list items.
+ */
+public class Item<T> {
+
+    @JsonProperty("value")
+    public final T value;
+
+    public Item(T value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/SampleCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/SampleCase.java
@@ -11,7 +11,7 @@ public class SampleCase {
     public final String contactNumber;
     public final String email;
     public final Address address;
-    public final List<ScannedDocument> scannedDocuments;
+    public final List<Item<ScannedDocument>> scannedDocuments;
 
     public SampleCase(
         String legacyId,
@@ -21,7 +21,7 @@ public class SampleCase {
         String contactNumber,
         String email,
         Address address,
-        List<ScannedDocument> scannedDocuments
+        List<Item<ScannedDocument>> scannedDocuments
     ) {
         this.legacyId = legacyId;
         this.firstName = firstName;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/ScannedDocument.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
 
 import java.time.LocalDateTime;
 
-@JsonRootName(value = "value")
 public class ScannedDocument {
 
     @JsonProperty

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 
 @Component
@@ -10,14 +11,14 @@ public class DocumentMapper {
     /**
      * Converts document in Exception Record model to document in Case model.
      */
-    public ScannedDocument toCaseDoc(
+    public Item<ScannedDocument> toCaseDoc(
         InputScannedDoc exceptionRecordDoc,
         String exceptionRecordReference
     ) {
         if (exceptionRecordDoc == null) {
             return null;
         } else {
-            return new ScannedDocument(
+            return new Item<>(new ScannedDocument(
                 exceptionRecordDoc.type,
                 exceptionRecordDoc.subtype,
                 exceptionRecordDoc.url,
@@ -26,7 +27,7 @@ public class DocumentMapper {
                 exceptionRecordDoc.scannedDate,
                 exceptionRecordDoc.deliveryDate,
                 exceptionRecordReference
-            );
+            ));
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenExceptio
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.UnauthenticatedException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.CaseCreationDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SampleCase;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
@@ -92,7 +93,7 @@ public class TransformationControllerTest {
                             "country"
                         ),
                         asList(
-                            new ScannedDocument(
+                            new Item<>(new ScannedDocument(
                                 "type-1",
                                 "subtype-1",
                                 "url-1",
@@ -101,8 +102,8 @@ public class TransformationControllerTest {
                                 LocalDateTime.parse("2011-12-03T10:15:30.123", ISO_DATE_TIME),
                                 LocalDateTime.parse("2011-12-04T10:15:30.123", ISO_DATE_TIME),
                                 "ref-1"
-                            ),
-                            new ScannedDocument(
+                            )),
+                            new Item<>(new ScannedDocument(
                                 "type-2",
                                 "subtype-2",
                                 "url-2",
@@ -111,7 +112,7 @@ public class TransformationControllerTest {
                                 LocalDateTime.parse("2011-12-05T10:15:30.123", ISO_DATE_TIME),
                                 LocalDateTime.parse("2011-12-06T10:15:30.123", ISO_DATE_TIME),
                                 "ref-2"
-                            )
+                            ))
                         )
                     )
                 ),
@@ -141,22 +142,22 @@ public class TransformationControllerTest {
             .andExpect(jsonPath("$.case_creation_details.case_data.address.postTown").value("post-town"))
             .andExpect(jsonPath("$.case_creation_details.case_data.address.county").value("county"))
             .andExpect(jsonPath("$.case_creation_details.case_data.address.country").value("country"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].type").value("type-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].subtype").value("subtype-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].url").value("url-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].controlNumber").value("dcn-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].fileName").value("file-name-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].scannedDate").value("2011-12-03T10:15:30.123"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].deliveryDate").value("2011-12-04T10:15:30.123"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].exceptionRecordReference").value("ref-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].type").value("type-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].subtype").value("subtype-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].url").value("url-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].controlNumber").value("dcn-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].fileName").value("file-name-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].scannedDate").value("2011-12-05T10:15:30.123"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].deliveryDate").value("2011-12-06T10:15:30.123"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].exceptionRecordReference").value("ref-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.type").value("type-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.subtype").value("subtype-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.url").value("url-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.controlNumber").value("dcn-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.fileName").value("file-name-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.scannedDate").value("2011-12-03T10:15:30.123"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.deliveryDate").value("2011-12-04T10:15:30.123"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.exceptionRecordReference").value("ref-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.type").value("type-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.subtype").value("subtype-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.url").value("url-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.controlNumber").value("dcn-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.fileName").value("file-name-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.scannedDate").value("2011-12-05T10:15:30.123"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.deliveryDate").value("2011-12-06T10:15:30.123"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.exceptionRecordReference").value("ref-2"))
             .andExpect(jsonPath("$.warnings[0]").value("warning-1"))
             .andExpect(jsonPath("$.warnings[1]").value("warning-2"));
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapperTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 
 import static java.time.LocalDateTime.now;
@@ -19,18 +20,18 @@ public class DocumentMapperTest {
         String refId = "ref-id";
 
         // when
-        ScannedDocument output = mapper.toCaseDoc(input, refId);
+        Item<ScannedDocument> output = mapper.toCaseDoc(input, refId);
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(output.type).isEqualTo(input.type);
-            softly.assertThat(output.subtype).isEqualTo(input.subtype);
-            softly.assertThat(output.url).isEqualTo(input.url);
-            softly.assertThat(output.controlNumber).isEqualTo(input.controlNumber);
-            softly.assertThat(output.fileName).isEqualTo(input.fileName);
-            softly.assertThat(output.deliveryDate).isEqualTo(input.deliveryDate);
-            softly.assertThat(output.scannedDate).isEqualTo(input.scannedDate);
-            softly.assertThat(output.exceptionRecordReference).isEqualTo(refId);
+            softly.assertThat(output.value.type).isEqualTo(input.type);
+            softly.assertThat(output.value.subtype).isEqualTo(input.subtype);
+            softly.assertThat(output.value.url).isEqualTo(input.url);
+            softly.assertThat(output.value.controlNumber).isEqualTo(input.controlNumber);
+            softly.assertThat(output.value.fileName).isEqualTo(input.fileName);
+            softly.assertThat(output.value.deliveryDate).isEqualTo(input.deliveryDate);
+            softly.assertThat(output.value.scannedDate).isEqualTo(input.scannedDate);
+            softly.assertThat(output.value.exceptionRecordReference).isEqualTo(refId);
         });
     }
 
@@ -41,7 +42,7 @@ public class DocumentMapperTest {
         String refId = "ref-id";
 
         // when
-        ScannedDocument output = mapper.toCaseDoc(input, refId);
+        Item<ScannedDocument> output = mapper.toCaseDoc(input, refId);
 
         // then
         assertThat(output).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.Excep
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Address;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SuccessfulTransformationResponse;
 
@@ -33,8 +34,8 @@ public class ExceptionRecordToCaseTransformerTest {
     @Mock private AddressExtractor addressExtractor;
     @Mock private ExceptionRecordValidator validator;
 
-    @Mock private ScannedDocument doc1;
-    @Mock private ScannedDocument doc2;
+    @Mock private Item<ScannedDocument> doc1;
+    @Mock private Item<ScannedDocument> doc2;
     @Mock private Address address;
 
     private ExceptionRecordToCaseTransformer service;


### PR DESCRIPTION
Unfortunately `@JsonRootName` Jackson annotation can only be used when wrapping feature is turned globally (it is only used to overwrite the default root wrapper name)