### PR TITLE
Removed contact form type

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
@@ -70,7 +70,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_return_warnings_when_optional_fields_are_missing() {
-        Response response = sendOcrFormValidationRequest("CONTACT", "missing-optional-fields.json");
+        Response response = sendOcrFormValidationRequest("PERSONAL", "missing-optional-fields.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 
@@ -84,7 +84,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_return_errors_when_additional_validations_are_failing() {
-        Response response = sendOcrFormValidationRequest("CONTACT", "invalid-form-data.json");
+        Response response = sendOcrFormValidationRequest("PERSONAL", "invalid-form-data.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
@@ -64,7 +64,7 @@ public class OcrFormValidationTest {
             .as(OcrValidationResponse.class, ObjectMapperType.JACKSON_2);
 
         assertThat(validationResponse.status).isEqualTo(ValidationStatus.ERRORS);
-        assertThat(validationResponse.errors).containsExactly("first_name is missing");
+        assertThat(validationResponse.errors).containsExactly("last_name is missing");
         assertThat(validationResponse.warnings).isEmpty();
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrFormValidationTest.java
@@ -21,6 +21,8 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 @TestPropertySource("classpath:application.conf")
 public class OcrFormValidationTest {
 
+    private static final String FORM_TYPE_PERSONAL = "PERSONAL";
+
     private String testUrl;
 
     private String s2sUrl;
@@ -42,7 +44,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_validate_ocr_data_and_return_success() {
-        Response response = sendOcrFormValidationRequest("PERSONAL", "valid-ocr-form-data.json");
+        Response response = sendOcrFormValidationRequest(FORM_TYPE_PERSONAL, "valid-ocr-form-data.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 
@@ -56,7 +58,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_return_errors_when_mandatory_fields_are_missing() {
-        Response response = sendOcrFormValidationRequest("PERSONAL", "missing-mandatory-fields.json");
+        Response response = sendOcrFormValidationRequest(FORM_TYPE_PERSONAL, "missing-mandatory-fields.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 
@@ -70,7 +72,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_return_warnings_when_optional_fields_are_missing() {
-        Response response = sendOcrFormValidationRequest("PERSONAL", "missing-optional-fields.json");
+        Response response = sendOcrFormValidationRequest(FORM_TYPE_PERSONAL, "missing-optional-fields.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 
@@ -84,7 +86,7 @@ public class OcrFormValidationTest {
 
     @Test
     public void should_return_errors_when_additional_validations_are_failing() {
-        Response response = sendOcrFormValidationRequest("PERSONAL", "invalid-form-data.json");
+        Response response = sendOcrFormValidationRequest(FORM_TYPE_PERSONAL, "invalid-form-data.json");
 
         assertThat(response.getStatusCode()).isEqualTo(200);
 

--- a/src/functionalTest/resources/invalid-form-data.json
+++ b/src/functionalTest/resources/invalid-form-data.json
@@ -1,5 +1,18 @@
 {
+  "_comment": "Invalid email and contact number format",
   "ocr_data_fields": [
+    {
+      "name": "first_name",
+      "value": "John"
+    },
+    {
+      "name": "last_name",
+      "value": "Smith"
+    },
+    {
+      "name": "date_of_birth",
+      "value": "2000-10-10"
+    },
     {
       "name": "address_line_1",
       "value": "12 Victoria Street"

--- a/src/functionalTest/resources/invalid-form-data.json
+++ b/src/functionalTest/resources/invalid-form-data.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Invalid email and contact_number",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/functionalTest/resources/invalid-form-data.json
+++ b/src/functionalTest/resources/invalid-form-data.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Invalid email and contact number format",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/functionalTest/resources/missing-mandatory-fields.json
+++ b/src/functionalTest/resources/missing-mandatory-fields.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Missing mandatory field last_name",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/functionalTest/resources/missing-mandatory-fields.json
+++ b/src/functionalTest/resources/missing-mandatory-fields.json
@@ -1,12 +1,48 @@
 {
   "ocr_data_fields": [
     {
-      "name": "last_name",
-      "value": "Smith"
+      "name": "first_name",
+      "value": "John"
     },
     {
       "name": "date_of_birth",
-      "value": "2000-10-10"
+      "value": "1990-01-31"
+    },
+    {
+      "name": "address_line_1",
+      "value": "1 Street"
+    },
+    {
+      "name": "address_line_2",
+      "value": "Victoria Street"
+    },
+    {
+      "name": "address_line_3",
+      "value": "London"
+    },
+    {
+      "name": "post_code",
+      "value": "1SW1 1ER"
+    },
+    {
+      "name": "post_town",
+      "value": "London"
+    },
+    {
+      "name": "county",
+      "value": "county"
+    },
+    {
+      "name": "country",
+      "value": "UK"
+    },
+    {
+      "name": "email",
+      "value": "xyz@something.com"
+    },
+    {
+      "name": "contact_number",
+      "value": "0123456789"
     }
   ]
 }

--- a/src/functionalTest/resources/missing-optional-fields.json
+++ b/src/functionalTest/resources/missing-optional-fields.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Missing optional fields post_town and county",
   "ocr_data_fields": [
     {
       "name": "first_name",
@@ -23,10 +24,6 @@
     {
       "name": "address_line_3",
       "value": "Victoria"
-    },
-    {
-      "name": "county",
-      "value": "London"
     },
     {
       "name": "post_code",

--- a/src/functionalTest/resources/missing-optional-fields.json
+++ b/src/functionalTest/resources/missing-optional-fields.json
@@ -1,12 +1,32 @@
 {
   "ocr_data_fields": [
     {
+      "name": "first_name",
+      "value": "John"
+    },
+    {
+      "name": "last_name",
+      "value": "Smith"
+    },
+    {
+      "name": "date_of_birth",
+      "value": "2000-10-10"
+    },
+    {
       "name": "address_line_1",
       "value": "12 Victoria Street"
     },
     {
-      "name": "email",
-      "value": "test@test.com"
+      "name": "address_line_2",
+      "value": "Victoria Street"
+    },
+    {
+      "name": "address_line_3",
+      "value": "Victoria"
+    },
+    {
+      "name": "county",
+      "value": "London"
     },
     {
       "name": "post_code",
@@ -17,16 +37,12 @@
       "value": "UK"
     },
     {
+      "name": "email",
+      "value": "xyz@something.com"
+    },
+    {
       "name": "contact_number",
       "value": "7890234567"
-    },
-    {
-      "name": "address_line_2",
-      "value": "Victoria Street"
-    },
-    {
-      "name": "address_line_3",
-      "value": "Victoria"
     }
   ]
 }

--- a/src/functionalTest/resources/valid-ocr-form-data.json
+++ b/src/functionalTest/resources/valid-ocr-form-data.json
@@ -11,6 +11,42 @@
     {
       "name": "date_of_birth",
       "value": "2000-10-10"
+    },
+    {
+      "name": "address_line_1",
+      "value": "12 Victoria Street"
+    },
+    {
+      "name": "address_line_2",
+      "value": "Victoria Street"
+    },
+    {
+      "name": "address_line_3",
+      "value": "Victoria"
+    },
+    {
+      "name": "post_town",
+      "value": "London"
+    },
+    {
+      "name": "county",
+      "value": "London"
+    },
+    {
+      "name": "post_code",
+      "value": "SW1 1EA"
+    },
+    {
+      "name": "country",
+      "value": "UK"
+    },
+    {
+      "name": "email",
+      "value": "xyz@something.com"
+    },
+    {
+      "name": "contact_number",
+      "value": "7890234567"
     }
   ]
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -88,8 +89,20 @@ class OcrValidationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("WARNINGS"))
             .andExpect(jsonPath("$.errors", hasSize(0)))
-            .andExpect(jsonPath("$.warnings", hasSize(1)))
-            .andExpect(jsonPath("$.warnings[0]").value("date_of_birth is missing"));
+            .andExpect(jsonPath("$.warnings[*]",
+                containsInAnyOrder(
+                    "address_line_1 is missing",
+                    "address_line_2 is missing",
+                    "address_line_3 is missing",
+                    "post_town is missing",
+                    "county is missing",
+                    "country is missing",
+                    "contact_number is missing",
+                    "post_code is missing",
+                    "email is missing",
+                    "date_of_birth is missing"
+                )
+            ));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/OcrValidationTest.java
@@ -110,7 +110,7 @@ class OcrValidationTest {
         String content = readResource("ocr-data/invalid/invalid-data-format.json");
 
         mvc.perform(
-            post("/forms/CONTACT/validate-ocr")
+            post("/forms/PERSONAL/validate-ocr")
                 .header("ServiceAuthorization", "auth-header-value")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content))

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/FormType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/model/FormType.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model;
 
 public enum FormType {
-    CONTACT,
     PERSONAL
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -87,16 +87,7 @@ public class OcrDataValidator {
     }
 
     private List<String> getMandatoryFieldsForForm(FormType formType) {
-        if (formType.equals(CONTACT)) {
-            return asList(
-                ADDRESS_LINE_1,
-                EMAIL,
-                POST_CODE,
-                COUNTRY,
-                CONTACT_NUMBER
-            );
-
-        } else if (formType.equals(PERSONAL)) {
+        if (formType.equals(PERSONAL)) {
             return Arrays.asList(
                 FIRST_NAME,
                 LAST_NAME
@@ -108,15 +99,19 @@ public class OcrDataValidator {
     }
 
     private List<String> getOptionalFieldsForForm(FormType formType) {
-        if (formType.equals(CONTACT)) {
+        if (formType.equals(PERSONAL)) {
             return asList(
+                ADDRESS_LINE_1,
                 ADDRESS_LINE_2,
                 ADDRESS_LINE_3,
                 POST_TOWN,
-                COUNTY
+                COUNTY,
+                COUNTRY,
+                CONTACT_NUMBER,
+                POST_CODE,
+                EMAIL,
+                DATE_OF_BIRTH
             );
-        } else if (formType.equals(PERSONAL)) {
-            return singletonList(DATE_OF_BIRTH);
         }
 
         log.info("Invalid Form type {}", formType);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -38,6 +37,21 @@ public class OcrDataValidator {
 
     private static final Logger log = LoggerFactory.getLogger(OcrDataValidator.class);
 
+    private static final List<String> personalFormMandatoryFields = asList(FIRST_NAME, LAST_NAME);
+
+    private static final List<String> personalFormOptionalFields = asList(
+        ADDRESS_LINE_1,
+        ADDRESS_LINE_2,
+        ADDRESS_LINE_3,
+        POST_TOWN,
+        COUNTY,
+        COUNTRY,
+        CONTACT_NUMBER,
+        POST_CODE,
+        EMAIL,
+        DATE_OF_BIRTH
+    );
+
     public OcrValidationResult validate(FormType formType, List<OcrDataField> ocrData) {
         List<String> duplicateOcrFields = OcrFormValidationHelper.findDuplicateOcrFields(ocrData);
 
@@ -66,10 +80,10 @@ public class OcrDataValidator {
             String email = OcrFormValidationHelper.findOcrFormFieldValue(EMAIL, ocrData);
             String phone = OcrFormValidationHelper.findOcrFormFieldValue(CONTACT_NUMBER, ocrData);
 
-            if (!errors.contains(EMAIL) && email != null && !isValidEmailAddress(email)) {
+            if (email != null && !isValidEmailAddress(email)) {
                 errors.add("Invalid email address");
             }
-            if (!errors.contains(CONTACT_NUMBER) && phone != null && !isValidPhoneNumber(phone)) {
+            if (phone != null && !isValidPhoneNumber(phone)) {
                 errors.add("Invalid phone number");
             }
         }
@@ -86,35 +100,11 @@ public class OcrDataValidator {
     }
 
     private List<String> getMandatoryFieldsForForm(FormType formType) {
-        if (formType.equals(PERSONAL)) {
-            return Arrays.asList(
-                FIRST_NAME,
-                LAST_NAME
-            );
-        }
-
-        log.info("Invalid Form type {}", formType);
-        return emptyList();
+        return formType.equals(PERSONAL) ? personalFormMandatoryFields : emptyList();
     }
 
     private List<String> getOptionalFieldsForForm(FormType formType) {
-        if (formType.equals(PERSONAL)) {
-            return asList(
-                ADDRESS_LINE_1,
-                ADDRESS_LINE_2,
-                ADDRESS_LINE_3,
-                POST_TOWN,
-                COUNTY,
-                COUNTRY,
-                CONTACT_NUMBER,
-                POST_CODE,
-                EMAIL,
-                DATE_OF_BIRTH
-            );
-        }
-
-        log.info("Invalid Form type {}", formType);
-        return emptyList();
+        return formType.equals(PERSONAL) ? personalFormOptionalFields : emptyList();
     }
 
     private ValidationStatus getValidationStatus(boolean errorsExist, boolean warningsExist) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -25,7 +25,6 @@ import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.F
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LAST_NAME;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_CODE;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_TOWN;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
@@ -63,14 +62,14 @@ public class OcrDataValidator {
         List<String> missingFields = OcrFormValidationHelper.findBlankFields(mandatoryFields, ocrData);
         List<String> errors = OcrFormValidationHelper.getErrorMessagesForMissingFields(missingFields);
 
-        if (formType.equals(CONTACT)) {
+        if (formType.equals(PERSONAL)) {
             String email = OcrFormValidationHelper.findOcrFormFieldValue(EMAIL, ocrData);
             String phone = OcrFormValidationHelper.findOcrFormFieldValue(CONTACT_NUMBER, ocrData);
 
-            if (!errors.contains(EMAIL) && !isValidEmailAddress(email)) {
+            if (!errors.contains(EMAIL) && email != null && !isValidEmailAddress(email)) {
                 errors.add("Invalid email address");
             }
-            if (!errors.contains(CONTACT_NUMBER) && !isValidPhoneNumber(phone)) {
+            if (!errors.contains(CONTACT_NUMBER) && phone != null && !isValidPhoneNumber(phone)) {
                 errors.add("Invalid phone number");
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/ocrvalidation/services/OcrDataValidator.java
@@ -76,16 +76,14 @@ public class OcrDataValidator {
         List<String> missingFields = OcrFormValidationHelper.findBlankFields(mandatoryFields, ocrData);
         List<String> errors = OcrFormValidationHelper.getErrorMessagesForMissingFields(missingFields);
 
-        if (formType.equals(PERSONAL)) {
-            String email = OcrFormValidationHelper.findOcrFormFieldValue(EMAIL, ocrData);
-            String phone = OcrFormValidationHelper.findOcrFormFieldValue(CONTACT_NUMBER, ocrData);
+        String email = OcrFormValidationHelper.findOcrFormFieldValue(EMAIL, ocrData);
+        String phone = OcrFormValidationHelper.findOcrFormFieldValue(CONTACT_NUMBER, ocrData);
 
-            if (email != null && !isValidEmailAddress(email)) {
-                errors.add("Invalid email address");
-            }
-            if (phone != null && !isValidPhoneNumber(phone)) {
-                errors.add("Invalid phone number");
-            }
+        if (email != null && !isValidEmailAddress(email)) {
+            errors.add("Invalid email address");
+        }
+        if (phone != null && !isValidPhoneNumber(phone)) {
+            errors.add("Invalid phone number");
         }
 
         return errors;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -34,7 +34,7 @@ class OcrDataValidatorTest {
     private final OcrDataValidator validator = new OcrDataValidator();
 
     @Test
-    void should_return_errors_when_mandatory_fields_are_missing() {
+    void should_return_errors_and_warnings_when_mandatory_and_optional_fields_are_missing() {
         // given
         List<OcrDataField> ocrDataFields = singletonList(new OcrDataField(FIRST_NAME, "test"));
 
@@ -45,9 +45,53 @@ class OcrDataValidatorTest {
         assertThat(result).isNotNull();
         assertThat(result)
             .extracting("errors", "warnings", "status")
+            .containsExactlyInAnyOrder(
+                singletonList("last_name is missing"),
+                asList(
+                    "address_line_1 is missing",
+                    "address_line_2 is missing",
+                    "address_line_3 is missing",
+                    "post_town is missing",
+                    "county is missing",
+                    "country is missing",
+                    "contact_number is missing",
+                    "post_code is missing",
+                    "email is missing",
+                    "date_of_birth is missing"
+                ),
+                ValidationStatus.ERRORS
+            );
+    }
+
+    @Test
+    void should_return_errors_and_warnings_when_mandatory_fields_are_empty_and_optional_fields_are_missing() {
+        // given
+        List<OcrDataField> ocrDataFields = asList(
+            new OcrDataField(FIRST_NAME, "test"),
+            new OcrDataField(LAST_NAME, ""),
+            new OcrDataField(DATE_OF_BIRTH, "01-01-1990")
+        );
+
+        // when
+        OcrValidationResult result = validator.validate(PERSONAL, ocrDataFields);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result)
+            .extracting("errors", "warnings", "status")
             .containsExactly(
                 singletonList("last_name is missing"),
-                singletonList("date_of_birth is missing"),
+                asList(
+                    "address_line_1 is missing",
+                    "address_line_2 is missing",
+                    "address_line_3 is missing",
+                    "post_town is missing",
+                    "county is missing",
+                    "country is missing",
+                    "contact_number is missing",
+                    "post_code is missing",
+                    "email is missing"
+                ),
                 ValidationStatus.ERRORS
             );
     }
@@ -83,7 +127,16 @@ class OcrDataValidatorTest {
             new OcrDataField(FIRST_NAME, "test"),
             new OcrDataField(LAST_NAME, "name"),
             new OcrDataField(DATE_OF_BIRTH, "01-01-1990"),
-            new OcrDataField("unrecognised_field", "xyz")
+            new OcrDataField("unrecognised_field", "xyz"),
+            new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
+            new OcrDataField(ADDRESS_LINE_3, "London"),
+            new OcrDataField(POST_TOWN, "LONDON"),
+            new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
+            new OcrDataField(COUNTRY, "UK"),
+            new OcrDataField(EMAIL, "xyz@something.com"),
+            new OcrDataField(CONTACT_NUMBER, "0123456789")
         );
 
         // when
@@ -97,57 +150,21 @@ class OcrDataValidatorTest {
     }
 
     @Test
-    void should_return_errors_when_mandatory_fields_are_empty() {
-        // given
-        List<OcrDataField> ocrDataFields = asList(
-            new OcrDataField(FIRST_NAME, "test"),
-            new OcrDataField(LAST_NAME, ""),
-            new OcrDataField(DATE_OF_BIRTH, "01-01-1990")
-        );
-
-        // when
-        OcrValidationResult result = validator.validate(PERSONAL, ocrDataFields);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result)
-            .extracting("errors", "warnings", "status")
-            .containsExactly(
-                singletonList("last_name is missing"),
-                emptyList(),
-                ValidationStatus.ERRORS
-            );
-    }
-
-    @Test
-    void should_return_warnings_when_optional_fields_are_empty() {
-        // given
-        List<OcrDataField> ocrDataFields = asList(
-            new OcrDataField(FIRST_NAME, "test"),
-            new OcrDataField(LAST_NAME, "test")
-        );
-
-        // when
-        OcrValidationResult result = validator.validate(PERSONAL, ocrDataFields);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result)
-            .extracting("errors", "warnings", "status")
-            .containsExactly(
-                emptyList(),
-                singletonList("date_of_birth is missing"),
-                ValidationStatus.WARNINGS
-            );
-    }
-
-    @Test
     void should_return_no_errors_when_ocr_data_contains_values_for_all_form_fields() {
         // given
         List<OcrDataField> ocrDataFields = asList(
             new OcrDataField(FIRST_NAME, "test"),
             new OcrDataField(LAST_NAME, "name"),
-            new OcrDataField(DATE_OF_BIRTH, "01-01-1990")
+            new OcrDataField(DATE_OF_BIRTH, "01-01-1990"),
+            new OcrDataField(ADDRESS_LINE_1, "1 Street"),
+            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
+            new OcrDataField(ADDRESS_LINE_3, "London"),
+            new OcrDataField(POST_TOWN, "LONDON"),
+            new OcrDataField(POST_CODE, "SW1 1ER"),
+            new OcrDataField(COUNTY, "county"),
+            new OcrDataField(COUNTRY, "UK"),
+            new OcrDataField(EMAIL, "xyz@something.com"),
+            new OcrDataField(CONTACT_NUMBER, "0123456789")
         );
 
         // when
@@ -164,6 +181,10 @@ class OcrDataValidatorTest {
     void should_validate_email_format_and_return_errors_for_invalid_value() {
         // given
         List<OcrDataField> ocrDataFields = asList(
+            new OcrDataField(FIRST_NAME, "test"),
+            new OcrDataField(LAST_NAME, "name"),
+            new OcrDataField(DATE_OF_BIRTH, "01-01-1990"),
+            new OcrDataField("unrecognised_field", "xyz"),
             new OcrDataField(ADDRESS_LINE_1, "1 Street"),
             new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
             new OcrDataField(ADDRESS_LINE_3, "London"),
@@ -171,7 +192,7 @@ class OcrDataValidatorTest {
             new OcrDataField(POST_CODE, "SW1 1ER"),
             new OcrDataField(COUNTY, "county"),
             new OcrDataField(COUNTRY, "UK"),
-            new OcrDataField(EMAIL, "xyz"), //invalid email address
+            new OcrDataField(EMAIL, "xyz@"),
             new OcrDataField(CONTACT_NUMBER, "0123456789")
         );
 
@@ -193,6 +214,10 @@ class OcrDataValidatorTest {
     void should_validate_phone_number_and_return_errors_for_invalid_value() {
         // given
         List<OcrDataField> ocrDataFields = asList(
+            new OcrDataField(FIRST_NAME, "test"),
+            new OcrDataField(LAST_NAME, "name"),
+            new OcrDataField(DATE_OF_BIRTH, "01-01-1990"),
+            new OcrDataField("unrecognised_field", "xyz"),
             new OcrDataField(ADDRESS_LINE_1, "1 Street"),
             new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
             new OcrDataField(ADDRESS_LINE_3, "London"),
@@ -200,7 +225,7 @@ class OcrDataValidatorTest {
             new OcrDataField(POST_CODE, "SW1 1ER"),
             new OcrDataField(COUNTY, "county"),
             new OcrDataField(COUNTRY, "UK"),
-            new OcrDataField(EMAIL, "test@test.com"),
+            new OcrDataField(EMAIL, "xyz@something.com"),
             new OcrDataField(CONTACT_NUMBER, "invalid") //invalid phone number
         );
 
@@ -217,60 +242,4 @@ class OcrDataValidatorTest {
                 ERRORS
             );
     }
-
-    @Test
-    void should_return_warnings_when_contact_form_optional_fields_are_missing() {
-        // given
-        List<OcrDataField> ocrDataFields = asList(
-            new OcrDataField(ADDRESS_LINE_1, "1 Street"),
-            new OcrDataField(POST_CODE, "SW1 1ER"),
-            new OcrDataField(COUNTY, "county"),
-            new OcrDataField(COUNTRY, "UK"),
-            new OcrDataField(EMAIL, "test@test.com"),
-            new OcrDataField(CONTACT_NUMBER, "0123456789")
-        );
-
-        // when
-        OcrValidationResult result = validator.validate(CONTACT, ocrDataFields);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result)
-            .extracting("errors", "warnings", "status")
-            .containsExactly(
-                emptyList(),
-                asList(
-                    "address_line_2 is missing",
-                    "address_line_3 is missing",
-                    "post_town is missing"
-                ),
-                ValidationStatus.WARNINGS
-            );
-    }
-
-    @Test
-    void should_return_success_when_contact_form_fields_format_is_valid() {
-        // given
-        List<OcrDataField> ocrDataFields = asList(
-            new OcrDataField(ADDRESS_LINE_1, "1 Street"),
-            new OcrDataField(ADDRESS_LINE_2, "Victoria Street"),
-            new OcrDataField(ADDRESS_LINE_3, "London"),
-            new OcrDataField(POST_TOWN, "LONDON"),
-            new OcrDataField(POST_CODE, "SW1 1ER"),
-            new OcrDataField(COUNTY, "county"),
-            new OcrDataField(COUNTRY, "UK"),
-            new OcrDataField(EMAIL, "test@test.com"), //valid email format
-            new OcrDataField(CONTACT_NUMBER, "0123456789") //valid phone number format
-        );
-
-        // when
-        OcrValidationResult result = validator.validate(CONTACT, ocrDataFields);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result)
-            .extracting("errors", "warnings", "status")
-            .containsExactly(emptyList(), emptyList(), SUCCESS);
-    }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/validators/OcrDataValidatorTest.java
@@ -24,7 +24,6 @@ import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.F
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.LAST_NAME;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_CODE;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames.POST_TOWN;
-import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.CONTACT;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.FormType.PERSONAL;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.ERRORS;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.out.ValidationStatus.SUCCESS;
@@ -197,7 +196,7 @@ class OcrDataValidatorTest {
         );
 
         // when
-        OcrValidationResult result = validator.validate(CONTACT, ocrDataFields);
+        OcrValidationResult result = validator.validate(PERSONAL, ocrDataFields);
 
         // then
         assertThat(result).isNotNull();
@@ -230,7 +229,7 @@ class OcrDataValidatorTest {
         );
 
         // when
-        OcrValidationResult result = validator.validate(CONTACT, ocrDataFields);
+        OcrValidationResult result = validator.validate(PERSONAL, ocrDataFields);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/resources/ocr-data/invalid/duplicate-fields.json
+++ b/src/test/resources/ocr-data/invalid/duplicate-fields.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Duplicate last_name field",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/test/resources/ocr-data/invalid/invalid-data-format.json
+++ b/src/test/resources/ocr-data/invalid/invalid-data-format.json
@@ -1,8 +1,20 @@
 {
   "ocr_data_fields": [
     {
+      "name": "first_name",
+      "value": "John"
+    },
+    {
+      "name": "last_name",
+      "value": "Smith"
+    },
+    {
+      "name": "date_of_birth",
+      "value": "10-10-2000"
+    },
+    {
       "name": "address_line_1",
-      "value": "12 Victoria Street"
+      "value": "1 Street"
     },
     {
       "name": "address_line_2",
@@ -10,7 +22,11 @@
     },
     {
       "name": "address_line_3",
-      "value": "Victoria"
+      "value": "London"
+    },
+    {
+      "name": "post_code",
+      "value": "1SW1 1ER"
     },
     {
       "name": "post_town",
@@ -18,11 +34,7 @@
     },
     {
       "name": "county",
-      "value": "London"
-    },
-    {
-      "name": "post_code",
-      "value": "SW1 1EA"
+      "value": "county"
     },
     {
       "name": "country",
@@ -30,11 +42,12 @@
     },
     {
       "name": "email",
-      "value": "invalid email"
+      "value": "invalid"
     },
     {
       "name": "contact_number",
-      "value": "invalid phone"
+      "value": "invalid"
     }
   ]
 }
+

--- a/src/test/resources/ocr-data/invalid/invalid-data-format.json
+++ b/src/test/resources/ocr-data/invalid/invalid-data-format.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Invalid email and contact_number",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Missing mandatory field last_name",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-mandatory-fields.json
@@ -7,6 +7,42 @@
     {
       "name": "date_of_birth",
       "value": "1990-01-31"
+    },
+    {
+      "name": "address_line_1",
+      "value": "1 Street"
+    },
+    {
+      "name": "address_line_2",
+      "value": "Victoria Street"
+    },
+    {
+      "name": "address_line_3",
+      "value": "London"
+    },
+    {
+      "name": "post_code",
+      "value": "1SW1 1ER"
+    },
+    {
+      "name": "post_town",
+      "value": "London"
+    },
+    {
+      "name": "county",
+      "value": "county"
+    },
+    {
+      "name": "country",
+      "value": "UK"
+    },
+    {
+      "name": "email",
+      "value": "xyz@something.com"
+    },
+    {
+      "name": "contact_number",
+      "value": "0123456789"
     }
   ]
 }

--- a/src/test/resources/ocr-data/invalid/missing-optional-fields.json
+++ b/src/test/resources/ocr-data/invalid/missing-optional-fields.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Missing optional fields address_line_1, address_line_2, address_line_3, post_town, county, country, contact_number, post_code, email, date_of_birth",
   "ocr_data_fields": [
     {
       "name": "first_name",

--- a/src/test/resources/ocr-data/valid/valid-ocr-data.json
+++ b/src/test/resources/ocr-data/valid/valid-ocr-data.json
@@ -11,6 +11,42 @@
     {
       "name": "date_of_birth",
       "value": "10-10-2000"
+    },
+    {
+      "name": "address_line_1",
+      "value": "1 Street"
+    },
+    {
+      "name": "address_line_2",
+      "value": "Victoria Street"
+    },
+    {
+      "name": "address_line_3",
+      "value": "London"
+    },
+    {
+      "name": "post_code",
+      "value": "1SW1 1ER"
+    },
+    {
+      "name": "post_town",
+      "value": "London"
+    },
+    {
+      "name": "county",
+      "value": "county"
+    },
+    {
+      "name": "country",
+      "value": "UK"
+    },
+    {
+      "name": "email",
+      "value": "xyz@something.com"
+    },
+    {
+      "name": "contact_number",
+      "value": "0123456789"
     }
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-683

### Change description ###

- Removed contact form type. As per the PR there will support for only one form type "Personal"

  - Mandatory fields will be `first_name` and `last_name`

  - Optional fields will be `address_line_1, `address_line_2, `address_line_3`, `post_town`,  `county`, `country`, `contact_number`, `post_code`,  `email`, `date_of_birth`

- Fixed tests(functional may need some fix - let's check PR build)

- TODO : Will create a separate PR to update the definition file for bulk scan jurisdiction(stored in shared infra)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```