### PR TITLE
Bump/Suppress versions of jackson-databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.8.RELEASE'
-  id 'org.springframework.boot' version '2.1.6.RELEASE'
+  id 'org.springframework.boot' version '2.1.8.RELEASE'
   id 'org.owasp.dependencycheck' version '5.1.1'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'org.sonarqube' version '2.7.1'
@@ -148,10 +148,6 @@ ext["rest-assured.version"] = '4.0.0'
 
 dependencyManagement {
   dependencies {
-    // CVE-2019-12814
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
-      entry 'jackson-databind'
-    }
     // CVE-2019-10086
     dependencySet(group: 'commons-beanutils', version: '1.9.4') {
       entry 'commons-beanutils'
@@ -175,7 +171,7 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
-  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.2.RELEASE'
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.1.3.RELEASE'
   compile group: 'commons-validator', name: 'commons-validator', version: '1.6'
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
   <suppress>
     <notes><![CDATA[ pulled by springfox and hystrix ]]></notes>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,6 +16,15 @@
     <cve>CVE-2018-1258</cve>
   </suppress>
 
+  <suppress until="2019-09-24">
+    <notes><![CDATA[
+   No fix available
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2019-14540</cve>
+    <cve>CVE-2019-16335</cve>
+  </suppress>
+
   <suppress>
     <notes><![CDATA[
       used in the smoke tests and functional tests.

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,7 +11,7 @@
     <notes><![CDATA[
      Suppressing as it seems a false positive
    ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.1\.5\.RELEASE$</gav>
+    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.1\.6\.RELEASE$</gav>
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>


### PR DESCRIPTION
### Change description ###

Using latest spring boot which has latest 2.9 series of jackson. Unfortunately `jackson-databind` 2.9.10 not yet available - suppressing that

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
