### PR TITLE
Provide CCD compatible `url`

### DIFF
--- a/src/functionalTest/resources/exception-records/invalid-missing-last-name.json
+++ b/src/functionalTest/resources/exception-records/invalid-missing-last-name.json
@@ -10,7 +10,11 @@
     {
       "type": "Form",
       "subtype": "XYZ",
-      "url": "url",
+      "url": {
+        "document_url": "url",
+        "document_binary_url": "binary-url",
+        "document_filename": "987654321-123456789.pdf"
+      },
       "control_number": "987654321",
       "file_name": "987654321-123456789.pdf",
       "scanned_date": "2019-08-01T00:01:02.345Z",

--- a/src/functionalTest/resources/exception-records/valid-missing-email.json
+++ b/src/functionalTest/resources/exception-records/valid-missing-email.json
@@ -11,7 +11,11 @@
     {
       "type": "Form",
       "subtype": "XYZ",
-      "url": "url",
+      "url": {
+        "document_url": "url",
+        "document_binary_url": "binary-url",
+        "document_filename": "987654321-123456789.pdf"
+      },
       "control_number": "987654321",
       "file_name": "987654321-123456789.pdf",
       "scanned_date": "2019-08-01T00:01:02.345Z",

--- a/src/functionalTest/resources/exception-records/valid.json
+++ b/src/functionalTest/resources/exception-records/valid.json
@@ -11,7 +11,11 @@
     {
       "type": "Form",
       "subtype": "XYZ",
-      "url": "url",
+      "url": {
+        "document_url": "url",
+        "document_binary_url": "binary-url",
+        "document_filename": "987654321-123456789.pdf"
+      },
       "control_number": "987654321",
       "file_name": "987654321-123456789.pdf",
       "scanned_date": "2019-08-01T00:01:02.345Z",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDoc.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDoc.java
@@ -8,7 +8,7 @@ public class InputScannedDoc {
 
     public final String type;
     public final String subtype;
-    public final String url;
+    public final InputScannedDocUrl document;
     public final String controlNumber;
     public final String fileName;
     public final LocalDateTime scannedDate;
@@ -17,7 +17,7 @@ public class InputScannedDoc {
     public InputScannedDoc(
         @JsonProperty("type") String type,
         @JsonProperty("subtype") String subtype,
-        @JsonProperty("url") String url,
+        @JsonProperty("url") InputScannedDocUrl document,
         @JsonProperty("control_number") String controlNumber,
         @JsonProperty("file_name") String fileName,
         @JsonProperty("scanned_date") LocalDateTime scannedDate,
@@ -25,7 +25,7 @@ public class InputScannedDoc {
     ) {
         this.type = type;
         this.subtype = subtype;
-        this.url = url;
+        this.document = document;
         this.controlNumber = controlNumber;
         this.fileName = fileName;
         this.scannedDate = scannedDate;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDocUrl.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/InputScannedDocUrl.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class InputScannedDocUrl {
+
+    public final String url;
+
+    public final String binaryUrl;
+
+    public final String filename;
+
+    public InputScannedDocUrl(
+        @JsonProperty("document_url") String url,
+        @JsonProperty("document_binary_url") String binaryUrl,
+        @JsonProperty("document_filename") String filename
+    ) {
+        this.url = url;
+        this.binaryUrl = binaryUrl;
+        this.filename = filename;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/DocumentUrl.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/DocumentUrl.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DocumentUrl {
+
+    @JsonProperty("document_url")
+    public final String url;
+
+    @JsonProperty("document_binary_url")
+    public final String binaryUrl;
+
+    @JsonProperty("document_filename")
+    public final String filename;
+
+    public DocumentUrl(
+        String url,
+        String binaryUrl,
+        String filename
+    ) {
+        this.url = url;
+        this.binaryUrl = binaryUrl;
+        this.filename = filename;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/ScannedDocument.java
@@ -12,8 +12,8 @@ public class ScannedDocument {
     @JsonProperty
     public final String subtype;
 
-    @JsonProperty
-    public final String url;
+    @JsonProperty("url")
+    public final DocumentUrl document;
 
     @JsonProperty
     public final String controlNumber;
@@ -33,7 +33,7 @@ public class ScannedDocument {
     public ScannedDocument(
         @JsonProperty("type") String type,
         @JsonProperty("subtype") String subtype,
-        @JsonProperty("url") String url,
+        @JsonProperty("url") DocumentUrl document,
         @JsonProperty("controlNumber") String controlNumber,
         @JsonProperty("fileName") String fileName,
         @JsonProperty("scannedDate") LocalDateTime scannedDate,
@@ -42,7 +42,7 @@ public class ScannedDocument {
     ) {
         this.type = type;
         this.subtype = subtype;
-        this.url = url;
+        this.document = document;
         this.controlNumber = controlNumber;
         this.fileName = fileName;
         this.scannedDate = scannedDate;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.DocumentUrl;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 
@@ -21,7 +22,11 @@ public class DocumentMapper {
             return new Item<>(new ScannedDocument(
                 exceptionRecordDoc.type,
                 exceptionRecordDoc.subtype,
-                exceptionRecordDoc.url,
+                new DocumentUrl(
+                    exceptionRecordDoc.document.url,
+                    exceptionRecordDoc.document.binaryUrl,
+                    exceptionRecordDoc.document.filename
+                ),
                 exceptionRecordDoc.controlNumber,
                 exceptionRecordDoc.fileName,
                 exceptionRecordDoc.scannedDate,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/InputHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/InputHelper.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler;
+
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDocUrl;
+
+import static java.time.LocalDateTime.now;
+
+public final class InputHelper {
+
+    private InputHelper() {
+        // utility class construct
+    }
+
+    public static InputScannedDoc getSampleInputDocument(String suffix) {
+        return new InputScannedDoc(
+            "type" + suffix,
+            "subtype" + suffix,
+            new InputScannedDocUrl(
+                "url" + suffix,
+                "binary-url" + suffix,
+                "hello.pdf" + suffix
+            ),
+            "dcn" + suffix,
+            "filename" + suffix,
+            now(),
+            now()
+        );
+    }
+
+    public static InputScannedDoc getSampleInputDocument() {
+        return getSampleInputDocument("");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenExceptio
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.UnauthenticatedException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.CaseCreationDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.DocumentUrl;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.SampleCase;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
@@ -98,7 +99,11 @@ public class TransformationControllerTest {
                             new Item<>(new ScannedDocument(
                                 "type-1",
                                 "subtype-1",
-                                "url-1",
+                                new DocumentUrl(
+                                    "url-1",
+                                    "binary-url-1",
+                                    "file-name-1"
+                                ),
                                 "dcn-1",
                                 "file-name-1",
                                 LocalDateTime.parse("2011-12-03T10:15:30.123", ISO_DATE_TIME),
@@ -108,7 +113,11 @@ public class TransformationControllerTest {
                             new Item<>(new ScannedDocument(
                                 "type-2",
                                 "subtype-2",
-                                "url-2",
+                                new DocumentUrl(
+                                    "url-2",
+                                    "binary-url-2",
+                                    "file-name-2"
+                                ),
                                 "dcn-2",
                                 "file-name-2",
                                 LocalDateTime.parse("2011-12-05T10:15:30.123", ISO_DATE_TIME),
@@ -146,7 +155,9 @@ public class TransformationControllerTest {
             .andExpect(jsonPath("$.case_creation_details.case_data.address.country").value("country"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.type").value("type-1"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.subtype").value("subtype-1"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.url").value("url-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.url.document_url").value("url-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.url.document_binary_url").value("binary-url-1"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.url.document_filename").value("file-name-1"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.controlNumber").value("dcn-1"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.fileName").value("file-name-1"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.scannedDate").value("2011-12-03T10:15:30.123"))
@@ -154,7 +165,9 @@ public class TransformationControllerTest {
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[0].value.exceptionRecordReference").value("ref-1"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.type").value("type-2"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.subtype").value("subtype-2"))
-            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.url").value("url-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.url.document_url").value("url-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.url.document_binary_url").value("binary-url-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.url.document_filename").value("file-name-2"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.controlNumber").value("dcn-2"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.fileName").value("file-name-2"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.scannedDate").value("2011-12-05T10:15:30.123"))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/DocumentMapperTest.java
@@ -5,9 +5,9 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.Input
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.ScannedDocument;
 
-import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.InputHelper.getSampleInputDocument;
 
 public class DocumentMapperTest {
 
@@ -16,7 +16,7 @@ public class DocumentMapperTest {
     @Test
     public void should_map_models() {
         // given
-        InputScannedDoc input = new InputScannedDoc("type", "subtype", "url", "dcn", "hello.pdf", now(), now());
+        InputScannedDoc input = getSampleInputDocument();
         String refId = "ref-id";
 
         // when
@@ -26,7 +26,9 @@ public class DocumentMapperTest {
         assertSoftly(softly -> {
             softly.assertThat(output.value.type).isEqualTo(input.type);
             softly.assertThat(output.value.subtype).isEqualTo(input.subtype);
-            softly.assertThat(output.value.url).isEqualTo(input.url);
+            softly.assertThat(output.value.document)
+                .usingRecursiveComparison()
+                .isEqualTo(input.document);
             softly.assertThat(output.value.controlNumber).isEqualTo(input.controlNumber);
             softly.assertThat(output.value.fileName).isEqualTo(input.fileName);
             softly.assertThat(output.value.deliveryDate).isEqualTo(input.deliveryDate);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
@@ -8,7 +8,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.OcrFieldNames;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.ocrvalidation.model.in.OcrDataField;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.InputScannedDoc;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.model.out.Item;
@@ -24,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static uk.gov.hmcts.reform.bulkscanccdeventhandler.InputHelper.getSampleInputDocument;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services.ExceptionRecordToCaseTransformer.CASE_TYPE_ID;
 import static uk.gov.hmcts.reform.bulkscanccdeventhandler.transformation.services.ExceptionRecordToCaseTransformer.EVENT_ID;
 
@@ -64,8 +64,8 @@ public class ExceptionRecordToCaseTransformerTest {
             now(),
             now(),
             asList(
-                new InputScannedDoc("type1", "subtype1", "url1", "dcn1", "filename1", now(), now()),
-                new InputScannedDoc("type2", "subtype2", "url2", "dcn2", "filename2", now(), now())
+                getSampleInputDocument("1"),
+                getSampleInputDocument("2")
             ),
             asList(
                 new OcrDataField(OcrFieldNames.FIRST_NAME, "John"),


### PR DESCRIPTION
### Change description ###

CCD expects an object as follows:

```json
{
  "document_url": "url",
  "document_binary_url": "binary-url",
  "document_filename": "filename
}
```

and not just `"url": "some string"` as it is at the moment.

All details are present in the callback so will shortly update the orchestrator too

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - input contract breaks. luckily - sample app + no service is using transformation on prod
[ ] No
```
