### PR TITLE
Add back exception record ID as it needs to reference in new service case

### DIFF
--- a/src/functionalTest/resources/exception-records/invalid-missing-last-name.json
+++ b/src/functionalTest/resources/exception-records/invalid-missing-last-name.json
@@ -1,4 +1,5 @@
 {
+  "id": "id",
   "case_type_id": "case_type_id",
   "po_box": "po_box",
   "po_box_jurisdiction": "bulkscan",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/in/ExceptionRecord.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public class ExceptionRecord {
 
+    public final String id;
     public final String caseTypeId;
     public final String poBox;
     public final String jurisdiction;
@@ -19,6 +20,7 @@ public class ExceptionRecord {
     public final List<OcrDataField> ocrDataFields;
 
     public ExceptionRecord(
+        @JsonProperty("id") String id,
         @JsonProperty("case_type_id") String caseTypeId,
         @JsonProperty("po_box") String poBox,
         @JsonProperty("po_box_jurisdiction") String jurisdiction,
@@ -29,6 +31,7 @@ public class ExceptionRecord {
         @JsonProperty("scanned_documents") List<InputScannedDoc> scannedDocuments,
         @JsonProperty("ocr_data_fields") List<OcrDataField> ocrDataFields
     ) {
+        this.id = id;
         this.caseTypeId = caseTypeId;
         this.poBox = poBox;
         this.jurisdiction = jurisdiction;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/SampleCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/model/out/SampleCase.java
@@ -12,6 +12,7 @@ public class SampleCase {
     public final String email;
     public final Address address;
     public final List<Item<ScannedDocument>> scannedDocuments;
+    public final String bulkScanCaseReference;
 
     public SampleCase(
         String legacyId,
@@ -21,7 +22,8 @@ public class SampleCase {
         String contactNumber,
         String email,
         Address address,
-        List<Item<ScannedDocument>> scannedDocuments
+        List<Item<ScannedDocument>> scannedDocuments,
+        String bulkScanCaseReference
     ) {
         this.legacyId = legacyId;
         this.firstName = firstName;
@@ -31,5 +33,6 @@ public class SampleCase {
         this.email = email;
         this.address = address;
         this.scannedDocuments = scannedDocuments;
+        this.bulkScanCaseReference = bulkScanCaseReference;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformer.java
@@ -66,7 +66,7 @@ public class ExceptionRecordToCaseTransformer {
             addressExtractor.extractFrom(er.ocrDataFields),
             er.scannedDocuments
                 .stream()
-                .map(it -> documentMapper.toCaseDoc(it, er.caseTypeId))
+                .map(it -> documentMapper.toCaseDoc(it, er.id))
                 .collect(toList())
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformer.java
@@ -67,7 +67,8 @@ public class ExceptionRecordToCaseTransformer {
             er.scannedDocuments
                 .stream()
                 .map(it -> documentMapper.toCaseDoc(it, er.id))
-                .collect(toList())
+                .collect(toList()),
+            er.id
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/controllers/TransformationControllerTest.java
@@ -124,7 +124,8 @@ public class TransformationControllerTest {
                                 LocalDateTime.parse("2011-12-06T10:15:30.123", ISO_DATE_TIME),
                                 "ref-2"
                             ))
-                        )
+                        ),
+                        "er-id"
                     )
                 ),
                 asList(
@@ -173,6 +174,7 @@ public class TransformationControllerTest {
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.scannedDate").value("2011-12-05T10:15:30.123"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.deliveryDate").value("2011-12-06T10:15:30.123"))
             .andExpect(jsonPath("$.case_creation_details.case_data.scannedDocuments[1].value.exceptionRecordReference").value("ref-2"))
+            .andExpect(jsonPath("$.case_creation_details.case_data.bulkScanCaseReference").value("er-id"))
             .andExpect(jsonPath("$.warnings[0]").value("warning-1"))
             .andExpect(jsonPath("$.warnings[1]").value("warning-2"));
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/CaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/CaseValidatorTest.java
@@ -40,7 +40,8 @@ public class CaseValidatorTest {
             "contact-number",
             email,
             new Address("line-1", "line-2", "line-3", "post-code", "post-town", "county", "country"),
-            emptyList()
+            emptyList(),
+            "er-id"
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordToCaseTransformerTest.java
@@ -60,6 +60,7 @@ public class ExceptionRecordToCaseTransformerTest {
             "er-case-type",
             "er-pobox",
             "er-jurisdiction",
+            "er-form-type",
             JourneyClassification.NEW_APPLICATION,
             now(),
             now(),
@@ -75,8 +76,8 @@ public class ExceptionRecordToCaseTransformerTest {
 
         // and
         given(addressExtractor.extractFrom(er.ocrDataFields)).willReturn(address);
-        given(documentMapper.toCaseDoc(er.scannedDocuments.get(0), er.caseTypeId)).willReturn(doc1);
-        given(documentMapper.toCaseDoc(er.scannedDocuments.get(1), er.caseTypeId)).willReturn(doc2);
+        given(documentMapper.toCaseDoc(er.scannedDocuments.get(0), er.id)).willReturn(doc1);
+        given(documentMapper.toCaseDoc(er.scannedDocuments.get(1), er.id)).willReturn(doc2);
         given(caseValidator.getWarnings(any())).willReturn(asList("w1", "w2"));
         // when
         SuccessfulTransformationResponse result = service.toCase(er);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/transformation/services/ExceptionRecordValidatorTest.java
@@ -68,6 +68,7 @@ public class ExceptionRecordValidatorTest {
             "er-case-type",
             "er-pobox",
             "er-jurisdiction",
+            "er-form-type",
             JourneyClassification.NEW_APPLICATION,
             now(),
             now(),


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

- Fix reference in scanned documents
- Include reference in new case to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
