### PR TITLE
Add update case endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
@@ -20,8 +20,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 @RestController
 public class UpdateCaseController {
 
-    public static final String EVENT_ID = "UpdateCase";
-
     private static final Logger LOGGER = getLogger(UpdateCaseController.class);
 
     private final AuthService authService;
@@ -48,11 +46,7 @@ public class UpdateCaseController {
         SampleCase updatedCase = caseUpdater.update(req.caseDetails.caseData, req.exceptionRecord);
 
         return new SuccessfulUpdateResponse(
-            new CaseUpdateDetails(
-                req.caseDetails.caseTypeId,
-                EVENT_ID,
-                updatedCase
-            ),
+            new CaseUpdateDetails(updatedCase),
             emptyList()
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.controllers;
+
+import org.slf4j.Logger;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in.CaseUpdate;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.CaseUpdateDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.SuccessfulUpdateResponse;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdater;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
+
+import javax.validation.Valid;
+
+import static java.util.Collections.emptyList;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@RestController
+public class UpdateCaseController {
+
+    public static final String EVENT_ID = "UpdateCase";
+
+    private static final Logger LOGGER = getLogger(UpdateCaseController.class);
+
+    private final AuthService authService;
+    private final CaseUpdater caseUpdater;
+
+    public UpdateCaseController(
+        AuthService authService,
+        CaseUpdater caseUpdater
+    ) {
+        this.authService = authService;
+        this.caseUpdater = caseUpdater;
+    }
+
+    @PostMapping("/update-case")
+    public SuccessfulUpdateResponse updateCase(
+        @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader,
+        @Valid @RequestBody CaseUpdate req
+    ) {
+        String serviceName = authService.authenticate(serviceAuthHeader);
+        LOGGER.info("Request received to update case. Service: {}", serviceName);
+
+        authService.assertIsAllowedService(serviceName);
+
+        SampleCase updatedCase = caseUpdater.update(req.caseDetails.caseData, req.exceptionRecord);
+
+        return new SuccessfulUpdateResponse(
+            new CaseUpdateDetails(
+                req.caseDetails.caseTypeId,
+                EVENT_ID,
+                updatedCase
+            ),
+            emptyList()
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.controllers;
 
-import org.slf4j.Logger;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -12,12 +11,8 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
 
 import javax.validation.Valid;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 @RestController
 public class UpdateCaseController {
-
-    private static final Logger LOGGER = getLogger(UpdateCaseController.class);
 
     private final AuthService authService;
     private final CaseUpdater caseUpdater;
@@ -38,8 +33,6 @@ public class UpdateCaseController {
         @Valid @RequestBody CaseUpdate req
     ) {
         String serviceName = authService.authenticate(serviceAuthHeader);
-        LOGGER.info("Request received to update case. Service: {}", serviceName);
-
         authService.assertIsAllowedService(serviceName);
 
         return caseUpdater.update(req);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
@@ -22,6 +22,8 @@ public class UpdateCaseController {
 
     private static final Logger LOGGER = getLogger(UpdateCaseController.class);
 
+    public static final String EVENT_ID = "SAMPLE_EVENT_ID";
+
     private final AuthService authService;
     private final CaseUpdater caseUpdater;
 
@@ -46,7 +48,10 @@ public class UpdateCaseController {
         SampleCase updatedCase = caseUpdater.update(req.caseDetails.caseData, req.exceptionRecord);
 
         return new SuccessfulUpdateResponse(
-            new CaseUpdateDetails(updatedCase),
+            // This is just a sample implementation.
+            // You can use different event IDs based on the changes made to a case.
+            new CaseUpdateDetails(EVENT_ID, updatedCase),
+            // This is just a sample implementation, put any warnings for the case worker here.
             emptyList()
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseController.java
@@ -6,15 +6,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in.CaseUpdate;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdater;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
 
 import javax.validation.Valid;
 
-import static java.util.Collections.emptyList;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @RestController
@@ -22,11 +19,10 @@ public class UpdateCaseController {
 
     private static final Logger LOGGER = getLogger(UpdateCaseController.class);
 
-    public static final String EVENT_ID = "SAMPLE_EVENT_ID";
-
     private final AuthService authService;
     private final CaseUpdater caseUpdater;
 
+    // region constructor
     public UpdateCaseController(
         AuthService authService,
         CaseUpdater caseUpdater
@@ -34,6 +30,7 @@ public class UpdateCaseController {
         this.authService = authService;
         this.caseUpdater = caseUpdater;
     }
+    // endregion
 
     @PostMapping("/update-case")
     public SuccessfulUpdateResponse updateCase(
@@ -45,14 +42,6 @@ public class UpdateCaseController {
 
         authService.assertIsAllowedService(serviceName);
 
-        SampleCase updatedCase = caseUpdater.update(req.caseDetails.caseData, req.exceptionRecord);
-
-        return new SuccessfulUpdateResponse(
-            // This is just a sample implementation.
-            // You can use different event IDs based on the changes made to a case.
-            new CaseUpdateDetails(EVENT_ID, updatedCase),
-            // This is just a sample implementation, put any warnings for the case worker here.
-            emptyList()
-        );
+        return caseUpdater.update(req);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/in/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/in/CaseDetails.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
+
+public class CaseDetails {
+
+    public final String caseTypeId;
+    public final SampleCase caseData;
+
+    public CaseDetails(
+        @JsonProperty("case_type_id") String caseTypeId,
+        @JsonProperty("case_data") SampleCase caseData
+    ) {
+        this.caseTypeId = caseTypeId;
+        this.caseData = caseData;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/in/CaseUpdate.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/in/CaseUpdate.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.in.ExceptionRecord;
+
+public class CaseUpdate {
+
+    public final ExceptionRecord exceptionRecord;
+    public final CaseDetails caseDetails;
+
+    public CaseUpdate(
+        @JsonProperty("exception_record") ExceptionRecord exceptionRecord,
+        @JsonProperty("case_details") CaseDetails caseDetails
+    ) {
+        this.exceptionRecord = exceptionRecord;
+        this.caseDetails = caseDetails;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
@@ -5,23 +5,11 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
 
 public class CaseUpdateDetails {
 
-    @JsonProperty("case_type_id")
-    public final String caseTypeId;
-
-    @JsonProperty("event_id")
-    public final String eventId;
-
     @JsonProperty("case_data")
     public final SampleCase caseData;
 
     // region constructor
-    public CaseUpdateDetails(
-        String caseTypeId,
-        String eventId,
-        SampleCase caseData
-    ) {
-        this.caseTypeId = caseTypeId;
-        this.eventId = eventId;
+    public CaseUpdateDetails(SampleCase caseData) {
         this.caseData = caseData;
     }
     // endregion

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
@@ -5,11 +5,18 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
 
 public class CaseUpdateDetails {
 
+    @JsonProperty("event_id")
+    public final String eventId;
+
     @JsonProperty("case_data")
     public final SampleCase caseData;
 
     // region constructor
-    public CaseUpdateDetails(SampleCase caseData) {
+    public CaseUpdateDetails(
+        String eventId,
+        SampleCase caseData
+    ) {
+        this.eventId = eventId;
         this.caseData = caseData;
     }
     // endregion

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/CaseUpdateDetails.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
+
+public class CaseUpdateDetails {
+
+    @JsonProperty("case_type_id")
+    public final String caseTypeId;
+
+    @JsonProperty("event_id")
+    public final String eventId;
+
+    @JsonProperty("case_data")
+    public final SampleCase caseData;
+
+    // region constructor
+    public CaseUpdateDetails(
+        String caseTypeId,
+        String eventId,
+        SampleCase caseData
+    ) {
+        this.caseTypeId = caseTypeId;
+        this.eventId = eventId;
+        this.caseData = caseData;
+    }
+    // endregion
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/SuccessfulUpdateResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/SuccessfulUpdateResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class SuccessfulUpdateResponse {
 
-    @JsonProperty("case_details")
+    @JsonProperty("case_update_details")
     public final CaseUpdateDetails caseUpdateDetails;
 
     @JsonProperty("warnings")

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/SuccessfulUpdateResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/model/out/SuccessfulUpdateResponse.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SuccessfulUpdateResponse {
+
+    @JsonProperty("case_details")
+    public final CaseUpdateDetails caseUpdateDetails;
+
+    @JsonProperty("warnings")
+    public final List<String> warnings;
+
+    // region constructor
+    public SuccessfulUpdateResponse(
+        CaseUpdateDetails caseUpdateDetails,
+        List<String> warnings
+    ) {
+        this.caseUpdateDetails = caseUpdateDetails;
+        this.warnings = warnings;
+    }
+    // endregion
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
@@ -1,13 +1,19 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services;
 
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.in.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in.CaseUpdate;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.CaseUpdateDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.Address;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.utils.AddressExtractor;
 
+import static java.util.Collections.emptyList;
+
 @Service
 public class CaseUpdater {
+
+    public static final String EVENT_ID = "SAMPLE_EVENT_ID";
 
     private final AddressExtractor addressExtractor;
 
@@ -15,21 +21,34 @@ public class CaseUpdater {
         this.addressExtractor = addressExtractor;
     }
 
-    public SampleCase update(SampleCase original, ExceptionRecord exceptionRecord) {
-        Address newAddress = addressExtractor.extractFrom(exceptionRecord.ocrDataFields);
+    public SuccessfulUpdateResponse update(CaseUpdate caseUpdate) {
+        Address newAddress = addressExtractor.extractFrom(caseUpdate.exceptionRecord.ocrDataFields);
+
+        SampleCase originalCase = caseUpdate.caseDetails.caseData;
 
         // This is just a sample implementation, we only overwrite the address here.
         // You'll probably update other fields and add new documents in your service case.
-        return new SampleCase(
-            original.legacyId,
-            original.firstName,
-            original.lastName,
-            original.dateOfBirth,
-            original.contactNumber,
-            original.email,
+        SampleCase newCase = new SampleCase(
+            originalCase.legacyId,
+            originalCase.firstName,
+            originalCase.lastName,
+            originalCase.dateOfBirth,
+            originalCase.contactNumber,
+            originalCase.email,
             newAddress,
-            original.scannedDocuments,
-            original.bulkScanCaseReference
+            originalCase.scannedDocuments,
+            originalCase.bulkScanCaseReference
+        );
+
+        return new SuccessfulUpdateResponse(
+            new CaseUpdateDetails(
+                // This is just a sample implementation.
+                // You can use different event IDs based on the changes made to a case.
+                EVENT_ID,
+                newCase
+            ),
+            // This is just a sample implementation, put any warnings for the case worker here.
+            emptyList()
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
@@ -43,11 +43,11 @@ public class CaseUpdater {
         return new SuccessfulUpdateResponse(
             new CaseUpdateDetails(
                 // This is just a sample implementation.
-                // You can use different event IDs based on the changes made to a case.
+                // You can use different event IDs based on the changes made to a case...
                 EVENT_ID,
                 newCase
             ),
-            // This is just a sample implementation, put any warnings for the case worker here.
+            // ... and put any warnings here.
             emptyList()
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdater.java
@@ -13,7 +13,7 @@ import static java.util.Collections.emptyList;
 @Service
 public class CaseUpdater {
 
-    public static final String EVENT_ID = "SAMPLE_EVENT_ID";
+    public static final String EVENT_ID = "attachScannedDocs";
 
     private final AddressExtractor addressExtractor;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -59,7 +59,7 @@ class UpdateCaseControllerTest {
     }
 
     @Test
-    public void should_return_expected_case_details() throws Exception {
+    public void should_return_updated_case_details() throws Exception {
         // given
         SampleCase sampleCase = new SampleCase(
             "legacy-id",
@@ -159,7 +159,6 @@ class UpdateCaseControllerTest {
             .andExpect(jsonPath("$.case_update_details.case_data.bulkScanCaseReference").value("er-id"))
             .andExpect(jsonPath("$.warnings[0]").value("warning-1"))
             .andExpect(jsonPath("$.warnings[1]").value("warning-2"));
-
     }
 
     private static Stream<Arguments> exceptionsAndStatuses() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -60,7 +60,6 @@ class UpdateCaseControllerTest {
 
     @Test
     public void should_return_updated_case_details() throws Exception {
-        // given
         SampleCase sampleCase = new SampleCase(
             "legacy-id",
             "first-name",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -14,6 +14,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.CaseUpdateDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdater;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenException;
@@ -107,12 +109,20 @@ class UpdateCaseControllerTest {
             ),
             "er-id"
         );
-        given(caseUpdater.update(any(), any())).willReturn(sampleCase);
+        given(caseUpdater.update(any()))
+            .willReturn(
+                new SuccessfulUpdateResponse(
+                    new CaseUpdateDetails(
+                        CaseUpdater.EVENT_ID,
+                        sampleCase
+                    ),
+                    asList("warning-1", "warning-2")
+                )
+            );
 
         sendRequest("{}")
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.case_update_details.case_type_id").value("case-type-id"))
-            .andExpect(jsonPath("$.case_update_details.event_id").value("event-id"))
+            .andExpect(jsonPath("$.case_update_details.event_id").value(CaseUpdater.EVENT_ID))
             .andExpect(jsonPath("$.case_update_details.case_data.legacyId").value("legacy-id"))
             .andExpect(jsonPath("$.case_update_details.case_data.firstName").value("first-name"))
             .andExpect(jsonPath("$.case_update_details.case_data.lastName").value("last-name"))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.controllers;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,14 +18,19 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdat
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.UnauthenticatedException;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.*;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("checkstyle:lineLength")
@@ -48,6 +54,102 @@ class UpdateCaseControllerTest {
 
         sendRequest("{}")
             .andExpect(status().is(status.value()));
+    }
+
+    @Test
+    public void should_return_expected_case_details() throws Exception {
+        // given
+        SampleCase sampleCase = new SampleCase(
+            "legacy-id",
+            "first-name",
+            "last-name",
+            "date-of-birth",
+            "contact-number",
+            "email",
+            new Address(
+                "address-line-1",
+                "address-line-2",
+                "address-line-3",
+                "post-code",
+                "post-town",
+                "county",
+                "country"
+            ),
+            asList(
+                new Item<>(new ScannedDocument(
+                    "type-1",
+                    "subtype-1",
+                    new DocumentUrl(
+                        "url-1",
+                        "binary-url-1",
+                        "file-name-1"
+                    ),
+                    "dcn-1",
+                    "file-name-1",
+                    LocalDateTime.parse("2011-12-03T10:15:30.123", ISO_DATE_TIME),
+                    LocalDateTime.parse("2011-12-04T10:15:30.123", ISO_DATE_TIME),
+                    "ref-1"
+                )),
+                new Item<>(new ScannedDocument(
+                    "type-2",
+                    "subtype-2",
+                    new DocumentUrl(
+                        "url-2",
+                        "binary-url-2",
+                        "file-name-2"
+                    ),
+                    "dcn-2",
+                    "file-name-2",
+                    LocalDateTime.parse("2011-12-05T10:15:30.123", ISO_DATE_TIME),
+                    LocalDateTime.parse("2011-12-06T10:15:30.123", ISO_DATE_TIME),
+                    "ref-2"
+                ))
+            ),
+            "er-id"
+        );
+        given(caseUpdater.update(any(), any())).willReturn(sampleCase);
+
+        sendRequest("{}")
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.case_update_details.case_type_id").value("case-type-id"))
+            .andExpect(jsonPath("$.case_update_details.event_id").value("event-id"))
+            .andExpect(jsonPath("$.case_update_details.case_data.legacyId").value("legacy-id"))
+            .andExpect(jsonPath("$.case_update_details.case_data.firstName").value("first-name"))
+            .andExpect(jsonPath("$.case_update_details.case_data.lastName").value("last-name"))
+            .andExpect(jsonPath("$.case_update_details.case_data.dateOfBirth").value("date-of-birth"))
+            .andExpect(jsonPath("$.case_update_details.case_data.contactNumber").value("contact-number"))
+            .andExpect(jsonPath("$.case_update_details.case_data.email").value("email"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.addressLine1").value("address-line-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.addressLine2").value("address-line-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.addressLine3").value("address-line-3"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.postCode").value("post-code"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.postTown").value("post-town"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.county").value("county"))
+            .andExpect(jsonPath("$.case_update_details.case_data.address.country").value("country"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.type").value("type-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.subtype").value("subtype-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.url.document_url").value("url-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.url.document_binary_url").value("binary-url-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.url.document_filename").value("file-name-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.controlNumber").value("dcn-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.fileName").value("file-name-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.scannedDate").value("2011-12-03T10:15:30.123"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.deliveryDate").value("2011-12-04T10:15:30.123"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[0].value.exceptionRecordReference").value("ref-1"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.type").value("type-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.subtype").value("subtype-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.url.document_url").value("url-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.url.document_binary_url").value("binary-url-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.url.document_filename").value("file-name-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.controlNumber").value("dcn-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.fileName").value("file-name-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.scannedDate").value("2011-12-05T10:15:30.123"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.deliveryDate").value("2011-12-06T10:15:30.123"))
+            .andExpect(jsonPath("$.case_update_details.case_data.scannedDocuments[1].value.exceptionRecordReference").value("ref-2"))
+            .andExpect(jsonPath("$.case_update_details.case_data.bulkScanCaseReference").value("er-id"))
+            .andExpect(jsonPath("$.warnings[0]").value("warning-1"))
+            .andExpect(jsonPath("$.warnings[1]").value("warning-2"));
+
     }
 
     private static Stream<Arguments> exceptionsAndStatuses() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -20,7 +20,11 @@ import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdat
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenException;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.UnauthenticatedException;
-import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.*;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.Address;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.DocumentUrl;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.Item;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.SampleCase;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.ScannedDocument;
 
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
@@ -45,7 +49,7 @@ class UpdateCaseControllerTest {
     @MockBean private AuthService authService;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         Mockito.reset(authService);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/controllers/UpdateCaseControllerTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.services.CaseUpdater;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.AuthService;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.ForbiddenException;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.auth.UnauthenticatedException;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("checkstyle:lineLength")
+@WebMvcTest(UpdateCaseController.class)
+class UpdateCaseControllerTest {
+
+    @Autowired private transient MockMvc mockMvc;
+
+    @MockBean private CaseUpdater caseUpdater;
+    @MockBean private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(authService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exceptionsAndStatuses")
+    public void should_return_proper_status_codes_for_auth_exceptions(RuntimeException exc, HttpStatus status) throws Exception {
+        given(authService.authenticate(any())).willThrow(exc);
+
+        sendRequest("{}")
+            .andExpect(status().is(status.value()));
+    }
+
+    private static Stream<Arguments> exceptionsAndStatuses() {
+        return Stream.of(
+            Arguments.of(new UnauthenticatedException(null), UNAUTHORIZED),
+            Arguments.of(new InvalidTokenException(null, null), UNAUTHORIZED),
+            Arguments.of(new ForbiddenException(null), FORBIDDEN)
+        );
+    }
+
+    private ResultActions sendRequest(String body) throws Exception {
+        return mockMvc
+            .perform(
+                post("/update-case")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in.CaseDetails;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.in.CaseUpdate;
+import uk.gov.hmcts.reform.bulkscanccdeventhandler.caseupdate.model.out.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.in.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.in.JourneyClassification;
 import uk.gov.hmcts.reform.bulkscanccdeventhandler.common.model.out.Address;
@@ -21,7 +24,8 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 public class CaseUpdaterTest {
 
-    @Mock private AddressExtractor addressExtractor;
+    @Mock
+    private AddressExtractor addressExtractor;
 
     private CaseUpdater caseUpdater;
 
@@ -65,18 +69,24 @@ public class CaseUpdaterTest {
         given(addressExtractor.extractFrom(any())).willReturn(exceptionRecordAddress);
 
         // when
-        SampleCase updatedCase = caseUpdater.update(originalCase, exceptionRecord);
+        SuccessfulUpdateResponse result =
+            caseUpdater.update(
+                new CaseUpdate(
+                    exceptionRecord,
+                    new CaseDetails("some_type", originalCase)
+                )
+            );
 
         // then
-        assertThat(updatedCase.address.addressLine1).isEqualTo(exceptionRecordAddress.addressLine1);
-        assertThat(updatedCase.address.addressLine2).isEqualTo(exceptionRecordAddress.addressLine2);
-        assertThat(updatedCase.address.addressLine3).isEqualTo(exceptionRecordAddress.addressLine3);
-        assertThat(updatedCase.address.country).isEqualTo(exceptionRecordAddress.country);
-        assertThat(updatedCase.address.county).isEqualTo(exceptionRecordAddress.county);
-        assertThat(updatedCase.address.postCode).isEqualTo(exceptionRecordAddress.postCode);
-        assertThat(updatedCase.address.postTown).isEqualTo(exceptionRecordAddress.postTown);
+        assertThat(result.caseUpdateDetails.caseData.address.addressLine1).isEqualTo(exceptionRecordAddress.addressLine1);
+        assertThat(result.caseUpdateDetails.caseData.address.addressLine2).isEqualTo(exceptionRecordAddress.addressLine2);
+        assertThat(result.caseUpdateDetails.caseData.address.addressLine3).isEqualTo(exceptionRecordAddress.addressLine3);
+        assertThat(result.caseUpdateDetails.caseData.address.country).isEqualTo(exceptionRecordAddress.country);
+        assertThat(result.caseUpdateDetails.caseData.address.county).isEqualTo(exceptionRecordAddress.county);
+        assertThat(result.caseUpdateDetails.caseData.address.postCode).isEqualTo(exceptionRecordAddress.postCode);
+        assertThat(result.caseUpdateDetails.caseData.address.postTown).isEqualTo(exceptionRecordAddress.postTown);
 
-        assertThat(updatedCase)
+        assertThat(result.caseUpdateDetails.caseData)
             .extracting(c -> tuple(
                 c.legacyId,
                 c.firstName,
@@ -91,5 +101,8 @@ public class CaseUpdaterTest {
                 originalCase.dateOfBirth,
                 originalCase.bulkScanCaseReference
             ));
+
+        assertThat(result.warnings).isEmpty();
+        assertThat(result.caseUpdateDetails.eventId).isEqualTo(CaseUpdater.EVENT_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+@SuppressWarnings("checkstyle:lineLength")
 @ExtendWith(MockitoExtension.class)
 public class CaseUpdaterTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscanccdeventhandler/caseupdate/services/CaseUpdaterTest.java
@@ -24,8 +24,7 @@ import static org.mockito.BDDMockito.given;
 @ExtendWith(MockitoExtension.class)
 public class CaseUpdaterTest {
 
-    @Mock
-    private AddressExtractor addressExtractor;
+    @Mock private AddressExtractor addressExtractor;
 
     private CaseUpdater caseUpdater;
 


### PR DESCRIPTION
Added controller for handling update requests.
Also refactored `CaseUpdater` service a bit to simplify testing.

Still to come (next PR): functional tests

https://tools.hmcts.net/jira/browse/BPS-845