### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-  id 'org.springframework.boot' version '2.3.0.RELEASE'
+  id 'org.springframework.boot' version '2.3.1.RELEASE'
   id 'org.owasp.dependencycheck' version '5.3.2.1'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'org.sonarqube' version '3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'org.springframework.boot' version '2.3.0.RELEASE'
   id 'org.owasp.dependencycheck' version '5.3.2.1'
   id 'com.github.ben-manes.versions' version '0.28.0'
-  id 'org.sonarqube' version '2.8'
+  id 'org.sonarqube' version '3.0'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ def versions = [
   reformLogging   : '5.1.5'
 ]
 
-ext["rest-assured.version"] = '4.2.0'
+ext["rest-assured.version"] = '4.3.0'
 
 dependencyManagement {
   dependencies {
@@ -151,6 +151,14 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: '3.3.3') {
       entry 'mockito-core'
     }
+    // force junit5 deps to use groovy v3 which fixes reflective call errors for java 11
+    // rest assured 4.2 -> 4.3 jumps to groovy v3. junit v5.6 still on v2.5
+    dependencySet(group: 'org.codehaus.groovy', version: '3.0.4') {
+      entry 'groovy'
+      entry 'groovy-json'
+      entry 'groovy-xml'
+    }
+
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ dependencies {
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 
-  implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4', withoutSpringCloudContext
+  implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0', withoutSpringCloudContext
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.3.RELEASE'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,7 +11,7 @@
     <notes><![CDATA[
      Suppressing as it seems a false positive
    ]]></notes>
-    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.3\.2\.RELEASE$</gav>
+    <gav regex="true">^org\.springframework\.security:spring-security-crypto:5\.3\.3\.RELEASE$</gav>
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
   </suppress>


### PR DESCRIPTION
### Change description ###

What's involved:

- SonarQube plugin 2.8 -> 3.0
- Spring boot 2.3.0 -> 2.3.1
- HMCTS properties lib 0.0.4 -> 0.1.0 (aligns involved spring boot deps)
- RestAssured 4.2.0 -> 4.3.0 (at last this happened!)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
