### PR TITLE
Do not include whole bulkscan product chart for main/stand-alone image

### DIFF
--- a/charts/bulk-scan-sample-app/values.aat.template.yaml
+++ b/charts/bulk-scan-sample-app/values.aat.template.yaml
@@ -3,3 +3,5 @@ java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   devApplicationInsightsInstrumentKey: "6a512449-6a07-4994-b08d-059b9146bbe9"
+bulk-scan:
+  enabled: false

--- a/charts/bulk-scan-sample-app/values.preview.template.yaml
+++ b/charts/bulk-scan-sample-app/values.preview.template.yaml
@@ -4,3 +4,5 @@ java:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+bulk-scan:
+  enabled: false


### PR DESCRIPTION
### Change description ###

Not having this flag causes very long pipeline build which raised suspicion to me as it is just a sample app - no db, no service bus, nothing.

Here's what's happening for PRs and aat staging:

```bash
17:10:43  coalesce.go:196: warning: cannot overwrite table with non table for keyVaults (map[draft-store:map[resourceGroup:draft-store-service secrets:[service-POSTGRES-PASS]]])
17:21:50  engine.go:159: [INFO] Missing required value: A resource group ( .Values.resourceGroup ) is required for storage creation
17:21:50  engine.go:159: [INFO] Missing required value: A team name (.Values.teamName) is required
17:21:50  engine.go:159: [INFO] Missing required value: A resource group ( .Values.servicebus.resourceGroup ) is required service bus creation
17:21:50  engine.go:159: [INFO] Missing required value: A team name (.Values.teamName) is required
```

Now that explains why I saw over 500MB for sample app image alone

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
