### PR TITLE
avoid  CVE-2020-8908 guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,8 @@ dependencyManagement {
     dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
     //avoid   CVE-2020-17527
     dependency group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.40'
+    // avoid  CVE-2020-8908
+    dependency group: 'com.google.guava', name: 'guava', version: '30.1-jre'
   }
 }
 


### PR DESCRIPTION

### Change description ###

avoid  CVE-2020-8908 use guava version 30

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
